### PR TITLE
Add support for java 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add this dependency to your project's POM:
 <dependency>
     <groupId>com.scalekit</groupId>
     <artifactId>scalekit-sdk-java</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -209,8 +209,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.scalekit</groupId>
     <artifactId>scalekit-sdk-java</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/com/scalekit/api/impl/ScalekitAuthClient.java
+++ b/src/main/java/com/scalekit/api/impl/ScalekitAuthClient.java
@@ -6,6 +6,15 @@ import com.scalekit.Environment;
 import com.scalekit.api.AuthClient;
 import com.scalekit.exceptions.APIException;
 import com.scalekit.internal.http.*;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 import org.jose4j.jwk.JsonWebKey;
 import org.jose4j.jwk.JsonWebKeySet;
 import org.jose4j.jwk.VerificationJwkSelector;
@@ -17,12 +26,11 @@ import org.jose4j.jwt.consumer.JwtConsumerBuilder;
 import org.jose4j.lang.JoseException;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.*;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -30,14 +38,20 @@ import static com.scalekit.internal.Constants.*;
 
 public class ScalekitAuthClient implements AuthClient {
 
-    private final HttpClient httpClient;
+    private final CloseableHttpClient httpClient;
     private final ObjectMapper objectMapper;
 
     public ScalekitAuthClient() {
 
-        this.httpClient = HttpClient.newBuilder()
-                .version(HttpClient.Version.HTTP_2)
-                .connectTimeout(Duration.ofSeconds(3))
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(5000)
+                .setSocketTimeout(10000)
+                .setConnectionRequestTimeout(5000)
+                .build();
+
+        // Create an HttpClient with the custom request configuration
+         this.httpClient = HttpClients.custom()
+                .setDefaultRequestConfig(requestConfig)
                 .build();
 
         this.objectMapper = new ObjectMapper();
@@ -67,7 +81,7 @@ public class ScalekitAuthClient implements AuthClient {
      * @param options: The AuthorizationUrlOptions
      * @return URL: The authorization URL
      */
-    public URL getAuthorizationUrl(String redirectUri, AuthorizationUrlOptions options){
+    public URL getAuthorizationUrl(String redirectUri, AuthorizationUrlOptions options) {
         List<String> scopes = new ArrayList<>();
         scopes.add("openid");
         scopes.add("profile");
@@ -78,46 +92,47 @@ public class ScalekitAuthClient implements AuthClient {
         }
 
         StringJoiner qs = new StringJoiner("&");
-        qs.add("response_type=code");
-        qs.add("client_id=" + URLEncoder.encode(Environment.defaultConfig().clientId, StandardCharsets.UTF_8));
-        qs.add("redirect_uri=" + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8));
-        qs.add("scope=" + URLEncoder.encode(String.join(" ", scopes), StandardCharsets.UTF_8));
-
-        if (options.getState() != null && !options.getState().isEmpty()) {
-            qs.add("state=" + URLEncoder.encode(options.getState(), StandardCharsets.UTF_8));
-        }
-        if (options.getNonce() != null && !options.getNonce().isEmpty()) {
-            qs.add("nonce=" + URLEncoder.encode(options.getNonce(), StandardCharsets.UTF_8));
-        }
-        if (options.getLoginHint() != null && !options.getLoginHint().isEmpty()) {
-            qs.add("login_hint=" + URLEncoder.encode(options.getLoginHint(), StandardCharsets.UTF_8));
-        }
-        if (options.getDomainHint() != null && !options.getDomainHint().isEmpty()) {
-            qs.add("domain_hint=" + URLEncoder.encode(options.getDomainHint(), StandardCharsets.UTF_8));
-            qs.add("domain=" + URLEncoder.encode(options.getDomainHint(), StandardCharsets.UTF_8));
-        }
-        if (options.getConnectionId() != null && !options.getConnectionId().isEmpty()) {
-            qs.add("connection_id=" + URLEncoder.encode(options.getConnectionId(), StandardCharsets.UTF_8));
-        }
-        if (options.getOrganizationId() != null && !options.getOrganizationId().isEmpty()) {
-            qs.add("organization_id=" + URLEncoder.encode(options.getOrganizationId(), StandardCharsets.UTF_8));
-        }
-        if (options.getCodeChallenge() != null && !options.getCodeChallenge().isEmpty()) {
-            qs.add("code_challenge=" + URLEncoder.encode(options.getCodeChallenge(), StandardCharsets.UTF_8));
-        }
-        if (options.getCodeChallengeMethod() != null && !options.getCodeChallengeMethod().isEmpty()) {
-            qs.add("code_challenge_method=" + URLEncoder.encode(options.getCodeChallengeMethod(), StandardCharsets.UTF_8));
-        }
-        if (options.getProvider() != null && !options.getProvider().isEmpty()) {
-            qs.add("provider=" + URLEncoder.encode(options.getProvider(), StandardCharsets.UTF_8));
-        }
-
-        String urlString = String.format("%s/%s?%s", Environment.defaultConfig().siteName , AUTHORIZATION_ENDPOINT, qs);
 
         try {
+            qs.add("response_type=code");
+            qs.add("client_id=" + URLEncoder.encode(Environment.defaultConfig().clientId, StandardCharsets.UTF_8.name()));
+            qs.add("redirect_uri=" + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8.name()));
+            qs.add("scope=" + URLEncoder.encode(String.join(" ", scopes), StandardCharsets.UTF_8.name()));
+
+            if (options.getState() != null && !options.getState().isEmpty()) {
+                qs.add("state=" + URLEncoder.encode(options.getState(), StandardCharsets.UTF_8.name()));
+            }
+            if (options.getNonce() != null && !options.getNonce().isEmpty()) {
+                qs.add("nonce=" + URLEncoder.encode(options.getNonce(), StandardCharsets.UTF_8.name()));
+            }
+            if (options.getLoginHint() != null && !options.getLoginHint().isEmpty()) {
+                qs.add("login_hint=" + URLEncoder.encode(options.getLoginHint(), StandardCharsets.UTF_8.name()));
+            }
+            if (options.getDomainHint() != null && !options.getDomainHint().isEmpty()) {
+                qs.add("domain_hint=" + URLEncoder.encode(options.getDomainHint(), StandardCharsets.UTF_8.name()));
+                qs.add("domain=" + URLEncoder.encode(options.getDomainHint(), StandardCharsets.UTF_8.name()));
+            }
+            if (options.getConnectionId() != null && !options.getConnectionId().isEmpty()) {
+                qs.add("connection_id=" + URLEncoder.encode(options.getConnectionId(), StandardCharsets.UTF_8.name()));
+            }
+            if (options.getOrganizationId() != null && !options.getOrganizationId().isEmpty()) {
+                qs.add("organization_id=" + URLEncoder.encode(options.getOrganizationId(), StandardCharsets.UTF_8.name()));
+            }
+            if (options.getCodeChallenge() != null && !options.getCodeChallenge().isEmpty()) {
+                qs.add("code_challenge=" + URLEncoder.encode(options.getCodeChallenge(), StandardCharsets.UTF_8.name()));
+            }
+            if (options.getCodeChallengeMethod() != null && !options.getCodeChallengeMethod().isEmpty()) {
+                qs.add("code_challenge_method=" + URLEncoder.encode(options.getCodeChallengeMethod(), StandardCharsets.UTF_8.name()));
+            }
+            if (options.getProvider() != null && !options.getProvider().isEmpty()) {
+                qs.add("provider=" + URLEncoder.encode(options.getProvider(), StandardCharsets.UTF_8.name()));
+            }
+
+            String urlString = String.format("%s/%s?%s", Environment.defaultConfig().siteName , AUTHORIZATION_ENDPOINT, qs);
+
             return new URL(urlString);
-        } catch (MalformedURLException e) {
-            throw new APIException("Invalid URL" + urlString + e.getMessage());
+        } catch (MalformedURLException | UnsupportedEncodingException e) {
+            throw new APIException("Invalid URL" + redirectUri + e.getMessage());
         }
     }
 
@@ -126,26 +141,44 @@ public class ScalekitAuthClient implements AuthClient {
      * @param jwt: The JWT token
      * @return boolean: True if the token is valid
      */
-    public boolean validateAccessToken(String jwt) throws APIException{
+    public boolean validateAccessToken(String jwt) throws APIException {
         try {
             // TODO Optimization - Cache the keys
-            String keysJson = this.httpClient.send(
-                    HttpRequest.newBuilder()
-                            .uri(new URI(Environment.defaultConfig().siteName + KEYS_ENDPOINT))
-                            .GET()
-                            .build(),
-                    HttpResponse.BodyHandlers.ofString()
-            ).body();
+            String keysJson = fetchJsonWebKeys();
 
+            // Parse the JSON keys into JsonWebKeySet
             JsonWebKeySet jsonWebKeySet = new JsonWebKeySet(keysJson);
+
+            // Setup the JWT signature verification
             JsonWebSignature jws = new JsonWebSignature();
             jws.setCompactSerialization(jwt);
+
             VerificationJwkSelector jwkSelector = new VerificationJwkSelector();
             JsonWebKey jwk = jwkSelector.select(jws, jsonWebKeySet.getJsonWebKeys());
             jws.setKey(jwk.getKey());
+
+            // Verify the signature
             return jws.verifySignature();
-        } catch (URISyntaxException | IOException | InterruptedException | JoseException e) {
-            throw new APIException("Failed to validate token:"+e.getMessage());
+        } catch (Exception e) {
+            throw new APIException("Failed to validate token: " + e.getMessage());
+        }
+    }
+
+    private String fetchJsonWebKeys() throws IOException {
+        String url = Environment.defaultConfig().siteName + KEYS_ENDPOINT;
+
+        // Create the GET request using Apache HttpClient
+        HttpGet httpGet = new HttpGet(URI.create(url));
+
+        try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
+            // Check if the response status is OK (200)
+            if (response.getStatusLine().getStatusCode() != 200) {
+                throw new IOException("Failed to fetch keys: " + EntityUtils.toString(response.getEntity()));
+            }
+
+            // Extract the response body (keys JSON)
+            HttpEntity entity = response.getEntity();
+            return EntityUtils.toString(entity, StandardCharsets.UTF_8);
         }
     }
 
@@ -206,19 +239,24 @@ public class ScalekitAuthClient implements AuthClient {
                 .map(entry -> entry.getKey() + "=" + entry.getValue())
                 .collect(Collectors.joining("&"));
 
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(new URI(url))
-                .header("Content-Type", "application/x-www-form-urlencoded")
-                .POST(HttpRequest.BodyPublishers.ofString(form, StandardCharsets.UTF_8))
-                .build();
+        HttpPost httpPost = new HttpPost(URI.create(url));
+        httpPost.setHeader("Content-Type", "application/x-www-form-urlencoded");
 
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
-        if (response.statusCode() != 200) {
-            throw new IOException("Failed to authenticate: " + response.body());
+        StringEntity entity = new StringEntity(form, StandardCharsets.UTF_8);
+        httpPost.setEntity(entity);
+
+        try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
+            // Check the response status
+            if (response.getStatusLine().getStatusCode() != 200) {
+                throw new IOException("Failed to authenticate: " + EntityUtils.toString(response.getEntity()));
+            }
+
+            // Parse the response body into AuthenticationResponse
+            HttpEntity responseEntity = response.getEntity();
+            String responseBody = EntityUtils.toString(responseEntity, StandardCharsets.UTF_8);
+            return objectMapper.readValue(responseBody, AuthenticationResponse.class);
         }
-
-        return objectMapper.readValue(response.body(), AuthenticationResponse.class);
     }
 
     /**

--- a/src/main/java/com/scalekit/api/impl/ScalekitAuthClient.java
+++ b/src/main/java/com/scalekit/api/impl/ScalekitAuthClient.java
@@ -23,13 +23,11 @@ import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.consumer.InvalidJwtException;
 import org.jose4j.jwt.consumer.JwtConsumer;
 import org.jose4j.jwt.consumer.JwtConsumerBuilder;
-import org.jose4j.lang.JoseException;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.*;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
+
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;

--- a/src/main/java/com/scalekit/api/impl/ScalekitAuthClient.java
+++ b/src/main/java/com/scalekit/api/impl/ScalekitAuthClient.java
@@ -144,10 +144,9 @@ public class ScalekitAuthClient implements AuthClient {
             // TODO Optimization - Cache the keys
             String keysJson = fetchJsonWebKeys();
 
-            // Parse the JSON keys into JsonWebKeySet
             JsonWebKeySet jsonWebKeySet = new JsonWebKeySet(keysJson);
 
-            // Setup the JWT signature verification
+
             JsonWebSignature jws = new JsonWebSignature();
             jws.setCompactSerialization(jwt);
 
@@ -165,16 +164,13 @@ public class ScalekitAuthClient implements AuthClient {
     private String fetchJsonWebKeys() throws IOException {
         String url = Environment.defaultConfig().siteName + KEYS_ENDPOINT;
 
-        // Create the GET request using Apache HttpClient
         HttpGet httpGet = new HttpGet(URI.create(url));
 
         try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
-            // Check if the response status is OK (200)
             if (response.getStatusLine().getStatusCode() != 200) {
                 throw new IOException("Failed to fetch keys: " + EntityUtils.toString(response.getEntity()));
             }
 
-            // Extract the response body (keys JSON)
             HttpEntity entity = response.getEntity();
             return EntityUtils.toString(entity, StandardCharsets.UTF_8);
         }

--- a/src/test/java/DirectoryTest.java
+++ b/src/test/java/DirectoryTest.java
@@ -4,14 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
 import com.scalekit.ScalekitClient;
-import com.scalekit.api.util.ListDirectoryGroupResponse;
-import com.scalekit.api.util.ListDirectoryResourceOptions;
-import com.scalekit.api.util.ListDirectoryUserResponse;
+import com.scalekit.api.util.*;
+import com.scalekit.grpc.scalekit.v1.directories.Directory;
 import com.scalekit.grpc.scalekit.v1.directories.DirectoryProvider;
 import com.scalekit.grpc.scalekit.v1.directories.ListDirectoriesResponse;
+import com.scalekit.grpc.scalekit.v1.directories.ToggleDirectoryResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 public class DirectoryTest {
@@ -47,9 +46,9 @@ public class DirectoryTest {
         ListDirectoriesResponse response = client.directories().listDirectories(organizationId);
         assertTrue(response.getDirectoriesCount() > 0);
 
-        var directoryById = client.directories().getDirectory(directoryId, organizationId);
+        Directory directoryById = client.directories().getDirectory(directoryId, organizationId);
 
-        var directory = response.getDirectories(0);
+        Directory directory = response.getDirectories(0);
         assertNotNull(directory);
         assertEquals(directoryId, directory.getId());
         assertEquals(organizationId, directory.getOrganizationId());
@@ -67,10 +66,10 @@ public class DirectoryTest {
         ListDirectoriesResponse response = client.directories().listDirectories(organizationId);
         assertTrue(response.getDirectoriesCount() > 0);
 
-        var directory = response.getDirectories(0);
+        Directory directory = response.getDirectories(0);
         assertNotNull(directory);
 
-        var options = ListDirectoryResourceOptions.builder()
+        ListDirectoryResourceOptions options = ListDirectoryResourceOptions.builder()
                 .pageSize(10)
                 .pageToken("")
                 .includeDetail(true)
@@ -83,7 +82,7 @@ public class DirectoryTest {
         assertTrue(usersResponse.getUsersCount() > 1);
 
         for (int i = 0; i < usersResponse.getUsersCount(); i++) {
-            var user = usersResponse.getUsers(i);
+            DirectoryUser user = usersResponse.getUsers(i);
             assertNotNull(user);
             assertNotNull(user.getId());
             assertNotNull(user.getEmail());
@@ -101,10 +100,10 @@ public class DirectoryTest {
         ListDirectoriesResponse response = client.directories().listDirectories(organizationId);
         assertTrue(response.getDirectoriesCount() > 0);
 
-        var directory = response.getDirectories(0);
+        Directory directory = response.getDirectories(0);
         assertNotNull(directory);
 
-        var options = ListDirectoryResourceOptions.builder()
+        ListDirectoryResourceOptions options = ListDirectoryResourceOptions.builder()
                 .pageSize(10)
                 .pageToken("")
                 .includeDetail(true)
@@ -117,7 +116,7 @@ public class DirectoryTest {
 
         assertEquals(usersResponse.getUsersCount() ,1);
 
-        var user = usersResponse.getUsers(0);
+        DirectoryUser user = usersResponse.getUsers(0);
         assertNotNull(user);
         assertNotNull(user.getId());
         assertNotNull(user.getEmail());
@@ -127,10 +126,10 @@ public class DirectoryTest {
     @Test
     public void EnableDisableDirectory(){
         try {
-            var enableResponse = client.directories().enableDirectory(directoryId, organizationId);
+            ToggleDirectoryResponse enableResponse = client.directories().enableDirectory(directoryId, organizationId);
             assertTrue(enableResponse.getEnabled());
 
-            var disableResponse = client.directories().disableDirectory(directoryId, organizationId);
+            ToggleDirectoryResponse disableResponse = client.directories().disableDirectory(directoryId, organizationId);
             assertFalse(disableResponse.getEnabled());
         }
         catch (Exception e){
@@ -146,10 +145,10 @@ public class DirectoryTest {
         ListDirectoriesResponse response = client.directories().listDirectories(organizationId);
         assertTrue(response.getDirectoriesCount() > 0);
 
-        var directory = response.getDirectories(0);
+        Directory directory = response.getDirectories(0);
         assertNotNull(directory);
 
-        var options = ListDirectoryResourceOptions.builder()
+        ListDirectoryResourceOptions options = ListDirectoryResourceOptions.builder()
                 .pageSize(10)
                 .pageToken("")
                 .includeDetail(true)
@@ -163,7 +162,7 @@ public class DirectoryTest {
         assertTrue(groupsResponse.getGroupsCount() > 0);
 
         for (int i = 0; i < groupsResponse.getGroupsCount(); i++) {
-            var group = groupsResponse.getGroups(i);
+            DirectoryGroup group = groupsResponse.getGroups(i);
             assertNotNull(group);
             assertNotNull(group.getId());
             assertNotNull(group.getDisplayName());
@@ -178,8 +177,8 @@ public class DirectoryTest {
 
     @Test
     public void GetDirectoryByOrganizationId(){
-        var directory = client.directories().getPrimaryDirectoryByOrganizationId(organizationId);
-        var directoryById = client.directories().getDirectory(directory.getId(), organizationId);
+        Directory directory = client.directories().getPrimaryDirectoryByOrganizationId(organizationId);
+        Directory directoryById = client.directories().getDirectory(directory.getId(), organizationId);
         assertNotNull(directory);
         assertNotNull(directoryById);
         assertEquals(directory.getId(), directoryById.getId());

--- a/src/test/java/OrganizationTests.java
+++ b/src/test/java/OrganizationTests.java
@@ -5,7 +5,7 @@ import com.scalekit.grpc.scalekit.v1.organizations.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
+import java.util.Arrays;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -133,14 +133,14 @@ public class OrganizationTests {
 
 
         Organization updatedOrganization = client.organizations()
-                .updateOrganizationSettings(organization.getId(), List.of(featureSSOEnable, featureDirectorySyncEnable));
+                .updateOrganizationSettings(organization.getId(), Arrays.asList(featureSSOEnable, featureDirectorySyncEnable));
 
         assertNotNull(updatedOrganization);
         assertTrue(updatedOrganization.getSettings().getFeaturesList().get(0).getEnabled());
         assertTrue(updatedOrganization.getSettings().getFeaturesList().get(1).getEnabled());
 
          updatedOrganization = client.organizations()
-                .updateOrganizationSettings(organization.getId(), List.of(featureSSODisable, featureDirectorySyncDisable));
+                .updateOrganizationSettings(organization.getId(), Arrays.asList(featureSSODisable, featureDirectorySyncDisable));
 
         assertNotNull(updatedOrganization);
         assertFalse(updatedOrganization.getSettings().getFeaturesList().get(0).getEnabled());


### PR DESCRIPTION

#### HTTP Client Update: 
* net/HttpClient was added in Java 11 removed the dependency
* Replaced the built-in `HttpClient` with `CloseableHttpClient` from Apache HttpComponents

#### URL Encoding:
* encoding was added in Java 10
* Wrapped URL encoding in a try-catch block to handle `UnsupportedEncodingException` and updated method calls to use `StandardCharsets.UTF_8.name()` for encoding.

#### Maven Configuration:
* Downgraded the Java version from 11 to 1.8 in the `pom.xml` file.

#### Change all var Keyword (only in tests)
