### PR TITLE
deploy  version 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 Add this dependency to your project's build file:
 
 ```gradle
-implementation "com.scalekit:scalekit-sdk-java:2.0.0"
+implementation "com.scalekit:scalekit-sdk-java:2.0.1"
 ```
 
 ### Maven users
@@ -41,7 +41,7 @@ Add this dependency to your project's POM:
 <dependency>
     <groupId>com.scalekit</groupId>
     <artifactId>scalekit-sdk-java</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.scalekit</groupId>
     <artifactId>scalekit-sdk-java</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/com/scalekit/internal/Constants.java
+++ b/src/main/java/com/scalekit/internal/Constants.java
@@ -4,7 +4,7 @@ import io.grpc.Metadata;
 import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
 public class Constants {
 
-    public static String version = "2.0.0";
+    public static String version = "2.0.1";
     public static String SCALEKIT_REQUEST_TIMEOUT = "SCALEKIT_REQUEST_TIMEOUT";
     public static final String BEARER_TYPE = "Bearer";
 


### PR DESCRIPTION
This pull request updates the `scalekit-sdk-java` dependency version from `2.0.0` to `2.0.1` 
