### PR TITLE
refactor(m2m): standardize method names to add/remove convention

### DIFF
--- a/src/main/java/com/scalekit/api/M2MClient.java
+++ b/src/main/java/com/scalekit/api/M2MClient.java
@@ -53,7 +53,7 @@ public interface M2MClient {
     void deleteOrganizationClient(String organizationId, String clientId);
 
     /**
-     * Creates a new secret for an M2M client.
+     * Adds a new secret to an M2M client.
      *
      * The plain secret value is returned only at creation time and cannot be retrieved again.
      *
@@ -61,16 +61,16 @@ public interface M2MClient {
      * @param clientId       The client ID to add a secret to
      * @return CreateOrganizationClientSecretResponse with secretId and plain secret
      */
-    CreateOrganizationClientSecretResponse createOrganizationClientSecret(String organizationId, String clientId);
+    CreateOrganizationClientSecretResponse addOrganizationClientSecret(String organizationId, String clientId);
 
     /**
-     * Permanently deletes a secret from an M2M client.
+     * Permanently removes a secret from an M2M client.
      *
      * @param organizationId The organization ID
      * @param clientId       The client ID
-     * @param secretId       The secret ID to delete
+     * @param secretId       The secret ID to remove
      */
-    void deleteOrganizationClientSecret(String organizationId, String clientId, String secretId);
+    void removeOrganizationClientSecret(String organizationId, String clientId, String secretId);
 
     /**
      * Lists all M2M clients for an organization with pagination.

--- a/src/main/java/com/scalekit/api/impl/ScalekitM2MClient.java
+++ b/src/main/java/com/scalekit/api/impl/ScalekitM2MClient.java
@@ -114,7 +114,7 @@ public class ScalekitM2MClient implements M2MClient {
     }
 
     @Override
-    public CreateOrganizationClientSecretResponse createOrganizationClientSecret(String organizationId, String clientId) {
+    public CreateOrganizationClientSecretResponse addOrganizationClientSecret(String organizationId, String clientId) {
         if (organizationId == null || organizationId.isEmpty()) {
             throw new IllegalArgumentException("organizationId is required");
         }
@@ -133,7 +133,7 @@ public class ScalekitM2MClient implements M2MClient {
     }
 
     @Override
-    public void deleteOrganizationClientSecret(String organizationId, String clientId, String secretId) {
+    public void removeOrganizationClientSecret(String organizationId, String clientId, String secretId) {
         if (organizationId == null || organizationId.isEmpty()) {
             throw new IllegalArgumentException("organizationId is required");
         }

--- a/src/test/java/M2MClientTests.java
+++ b/src/test/java/M2MClientTests.java
@@ -135,7 +135,7 @@ public class M2MClientTests {
     }
 
     @Test
-    void testCreateOrganizationClientSecret() {
+    void testAddOrganizationClientSecret() {
         OrganizationClient clientProto = OrganizationClient.newBuilder()
                 .setName("Secret Test Client")
                 .build();
@@ -146,21 +146,21 @@ public class M2MClientTests {
 
         try {
             CreateOrganizationClientSecretResponse secretResp =
-                    client.m2m().createOrganizationClientSecret(testOrgId, clientId);
+                    client.m2m().addOrganizationClientSecret(testOrgId, clientId);
 
             assertNotNull(secretResp);
             assertFalse(secretResp.getSecret().getId().isEmpty());
             assertFalse(secretResp.getPlainSecret().isEmpty());
 
             // Cleanup secret
-            client.m2m().deleteOrganizationClientSecret(testOrgId, clientId, secretResp.getSecret().getId());
+            client.m2m().removeOrganizationClientSecret(testOrgId, clientId, secretResp.getSecret().getId());
         } finally {
             client.m2m().deleteOrganizationClient(testOrgId, clientId);
         }
     }
 
     @Test
-    void testDeleteOrganizationClientSecret() {
+    void testRemoveOrganizationClientSecret() {
         OrganizationClient clientProto = OrganizationClient.newBuilder()
                 .setName("Delete Secret Client")
                 .build();
@@ -171,21 +171,21 @@ public class M2MClientTests {
 
         try {
             CreateOrganizationClientSecretResponse secretResp =
-                    client.m2m().createOrganizationClientSecret(testOrgId, clientId);
+                    client.m2m().addOrganizationClientSecret(testOrgId, clientId);
             String secretId = secretResp.getSecret().getId();
 
             // Should not throw
             assertDoesNotThrow(() ->
-                    client.m2m().deleteOrganizationClientSecret(testOrgId, clientId, secretId));
+                    client.m2m().removeOrganizationClientSecret(testOrgId, clientId, secretId));
         } finally {
             client.m2m().deleteOrganizationClient(testOrgId, clientId);
         }
     }
 
     @Test
-    void testDeleteOrganizationClientSecretRequiresSecretId() {
+    void testRemoveOrganizationClientSecretRequiresSecretId() {
         assertThrows(IllegalArgumentException.class, () ->
-                client.m2m().deleteOrganizationClientSecret(testOrgId, "skc_dummy", ""));
+                client.m2m().removeOrganizationClientSecret(testOrgId, "skc_dummy", ""));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Rename `addOrganizationClientSecret()` method interface and implementation
- Rename `removeOrganizationClientSecret()` method interface and implementation
- Update method calls in test suite
- Update JSDoc comments to reflect action verbs (add/remove)
- Standardizes Java SDK naming to match Python SDK convention

## Test plan
- All existing tests updated and passing
- M2M client creation, update, and deletion flows remain unchanged
- Only method names are updated, functionality is identical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Renamed M2M client API methods for improved semantic clarity: `createOrganizationClientSecret` is now `addOrganizationClientSecret`, and `deleteOrganizationClientSecret` is now `removeOrganizationClientSecret`. These naming conventions provide a more intuitive interface for managing organization client secrets. Developers using the M2M client must update their code to use the new method names. Underlying functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->