### PR TITLE
fix: correct enum class name in updateOrganizationSessionPolicy Javadoc

### DIFF
--- a/src/main/java/com/scalekit/api/impl/ScalekitOrganizationClient.java
+++ b/src/main/java/com/scalekit/api/impl/ScalekitOrganizationClient.java
@@ -304,7 +304,7 @@ public class ScalekitOrganizationClient implements OrganizationClient {
     /**
      * updateOrganizationSessionPolicy sets a custom session policy for an organization or reverts to application defaults.
      * @param organizationId Organization identifier
-     * @param policy The policy to apply (use SessionPolicySource.APPLICATION to revert to defaults)
+     * @param policy The policy to apply (use SessionPolicyType.APPLICATION to revert to defaults)
      * @return Updated OrganizationSessionPolicySettings
      */
     @Override


### PR DESCRIPTION
## Summary
- Fixes a typo in the `updateOrganizationSessionPolicy` Javadoc: `SessionPolicySource.APPLICATION` → `SessionPolicyType.APPLICATION`
- `SessionPolicySource` does not exist; the correct class is `SessionPolicyType`

## Test plan
- [ ] No behaviour change — doc comment fix only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated session policy documentation for accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/scalekit-sdk-java/pull/60)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->