### PR TITLE
feat(org): add slug integration tests

### DIFF
--- a/src/test/java/OrganizationTests.java
+++ b/src/test/java/OrganizationTests.java
@@ -227,6 +227,33 @@ public class OrganizationTests {
     }
 
     @Test
+    void SlugTest() {
+        String slug = "test-slug-" + System.currentTimeMillis();
+
+        CreateOrganization createOrganization = CreateOrganization.newBuilder()
+                .setDisplayName("Slug Test Org")
+                .setExternalId(UUID.randomUUID().toString().substring(0, 10))
+                .setSlug(slug)
+                .build();
+
+        Organization createdOrganization = client.organizations().create(createOrganization);
+        assertNotNull(createdOrganization);
+        assertEquals(slug, createdOrganization.getSlug());
+
+        Organization retrieved = client.organizations().getById(createdOrganization.getId());
+        assertEquals(slug, retrieved.getSlug());
+
+        String updatedSlug = "upd-slug-" + System.currentTimeMillis();
+        Organization updated = client.organizations().updateById(
+                createdOrganization.getId(),
+                UpdateOrganization.newBuilder().setSlug(updatedSlug).build()
+        );
+        assertEquals(updatedSlug, updated.getSlug());
+
+        client.organizations().deleteById(createdOrganization.getId());
+    }
+
+    @Test
     void UpsertUserManagementSettingsTest() {
         ListOrganizationsResponse organizations = client.organizations().listOrganizations(10, null);
         assertNotNull(organizations);


### PR DESCRIPTION
## Summary
- `slug` is already present in the generated protobuf types (`CreateOrganization.Builder.setSlug()`, `UpdateOrganization.Builder.setSlug()`, `Organization.getSlug()`)
- Add `SlugTest` to verify slug round-trips correctly through create, get, and update

## Test plan
- [ ] `SlugTest` — creates org with slug via `setSlug()`, asserts `getSlug()` on create response and `getById` response, then updates slug and asserts new value

Run with staging credentials:
```
SCALEKIT_ENVIRONMENT_URL=... SCALEKIT_CLIENT_ID=... SCALEKIT_CLIENT_SECRET=... \
  mvn test -Dtest=OrganizationTests#SlugTest
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for organization slug functionality, including creation, retrieval, updates, and deletion operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/scalekit-sdk-java/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->