### PR TITLE
feat(users): add external_id lookup methods

### DIFF
--- a/src/main/java/com/scalekit/api/UserClient.java
+++ b/src/main/java/com/scalekit/api/UserClient.java
@@ -30,4 +30,16 @@ public interface UserClient {
     ListUserRolesResponse listUserRoles(String organizationId, String userId);
 
     ListUserPermissionsResponse listUserPermissions(String organizationId, String userId);
-} 
+
+    GetUserResponse getUserByExternalId(String externalId);
+
+    UpdateUserResponse updateUserByExternalId(String externalId, UpdateUserRequest request);
+
+    void deleteUserByExternalId(String externalId);
+
+    CreateMembershipResponse createMembershipByExternalId(String organizationId, String externalId, CreateMembershipRequest request);
+
+    void deleteMembershipByExternalId(String organizationId, String externalId);
+
+    UpdateMembershipResponse updateMembershipByExternalId(String organizationId, String externalId, UpdateMembershipRequest request);
+}

--- a/src/main/java/com/scalekit/api/impl/ScalekitUserClient.java
+++ b/src/main/java/com/scalekit/api/impl/ScalekitUserClient.java
@@ -279,4 +279,112 @@ public class ScalekitUserClient implements UserClient {
                     .listUserPermissions(request);
         }, this.credentials);
     }
-} 
+
+    /**
+     * Retrieves a user by their external ID
+     * @param externalId: The external ID of the user to retrieve
+     * @return GetUserResponse: The response containing the user details
+     */
+    @Override
+    public GetUserResponse getUserByExternalId(String externalId) {
+        return RetryExecuter.executeWithRetry(() -> {
+            GetUserRequest request = GetUserRequest.newBuilder()
+                    .setExternalId(externalId)
+                    .build();
+            return userService
+                    .withDeadlineAfter(Environment.defaultConfig().timeout, TimeUnit.MILLISECONDS)
+                    .getUser(request);
+        }, this.credentials);
+    }
+
+    /**
+     * Updates a user identified by their external ID
+     * @param externalId: The external ID of the user to update
+     * @param request: The update user request containing the changes
+     * @return UpdateUserResponse: The response containing the updated user
+     */
+    @Override
+    public UpdateUserResponse updateUserByExternalId(String externalId, UpdateUserRequest request) {
+        return RetryExecuter.executeWithRetry(() -> {
+            return userService
+                    .withDeadlineAfter(Environment.defaultConfig().timeout, TimeUnit.MILLISECONDS)
+                    .updateUser(request.toBuilder()
+                            .setExternalId(externalId)
+                            .build());
+        }, this.credentials);
+    }
+
+    /**
+     * Deletes a user identified by their external ID
+     * @param externalId: The external ID of the user to delete
+     */
+    @Override
+    public void deleteUserByExternalId(String externalId) {
+        RetryExecuter.executeWithRetry(() -> {
+            DeleteUserRequest request = DeleteUserRequest.newBuilder()
+                    .setExternalId(externalId)
+                    .build();
+            userService
+                    .withDeadlineAfter(Environment.defaultConfig().timeout, TimeUnit.MILLISECONDS)
+                    .deleteUser(request);
+            return null;
+        }, this.credentials);
+    }
+
+    /**
+     * Creates a membership for a user identified by their external ID in the specified organization
+     * @param organizationId: The organization ID
+     * @param externalId: The external ID of the user to create membership for
+     * @param request: The create membership request containing membership details
+     * @return CreateMembershipResponse: The response containing the created membership
+     */
+    @Override
+    public CreateMembershipResponse createMembershipByExternalId(String organizationId, String externalId, CreateMembershipRequest request) {
+        return RetryExecuter.executeWithRetry(() -> {
+            return userService
+                    .withDeadlineAfter(Environment.defaultConfig().timeout, TimeUnit.MILLISECONDS)
+                    .createMembership(request.toBuilder()
+                            .setOrganizationId(organizationId)
+                            .setExternalId(externalId)
+                            .build());
+        }, this.credentials);
+    }
+
+    /**
+     * Deletes a membership for a user identified by their external ID from the specified organization
+     * @param organizationId: The organization ID
+     * @param externalId: The external ID of the user whose membership to delete
+     */
+    @Override
+    public void deleteMembershipByExternalId(String organizationId, String externalId) {
+        RetryExecuter.executeWithRetry(() -> {
+            DeleteMembershipRequest request = DeleteMembershipRequest.newBuilder()
+                    .setOrganizationId(organizationId)
+                    .setExternalId(externalId)
+                    .build();
+            userService
+                    .withDeadlineAfter(Environment.defaultConfig().timeout, TimeUnit.MILLISECONDS)
+                    .deleteMembership(request);
+            return null;
+        }, this.credentials);
+    }
+
+    /**
+     * Updates a membership for a user identified by their external ID in the specified organization
+     * @param organizationId: The organization ID
+     * @param externalId: The external ID of the user whose membership to update
+     * @param request: The update membership request containing the changes
+     * @return UpdateMembershipResponse: The response containing the updated membership
+     */
+    @Override
+    public UpdateMembershipResponse updateMembershipByExternalId(String organizationId, String externalId, UpdateMembershipRequest request) {
+        return RetryExecuter.executeWithRetry(() -> {
+            return userService
+                    .withDeadlineAfter(Environment.defaultConfig().timeout, TimeUnit.MILLISECONDS)
+                    .updateMembership(request.toBuilder()
+                            .setOrganizationId(organizationId)
+                            .setExternalId(externalId)
+                            .build());
+        }, this.credentials);
+    }
+}

--- a/src/main/java/com/scalekit/api/impl/ScalekitUserClient.java
+++ b/src/main/java/com/scalekit/api/impl/ScalekitUserClient.java
@@ -280,6 +280,20 @@ public class ScalekitUserClient implements UserClient {
         }, this.credentials);
     }
 
+    private static String requireNonBlank(String value, String field) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(field + " is required");
+        }
+        return value;
+    }
+
+    private static <T> T requireNonNull(T value, String field) {
+        if (value == null) {
+            throw new IllegalArgumentException(field + " is required");
+        }
+        return value;
+    }
+
     /**
      * Retrieves a user by their external ID
      * @param externalId: The external ID of the user to retrieve
@@ -287,6 +301,7 @@ public class ScalekitUserClient implements UserClient {
      */
     @Override
     public GetUserResponse getUserByExternalId(String externalId) {
+        requireNonBlank(externalId, "externalId");
         return RetryExecuter.executeWithRetry(() -> {
             GetUserRequest request = GetUserRequest.newBuilder()
                     .setExternalId(externalId)
@@ -305,6 +320,8 @@ public class ScalekitUserClient implements UserClient {
      */
     @Override
     public UpdateUserResponse updateUserByExternalId(String externalId, UpdateUserRequest request) {
+        requireNonBlank(externalId, "externalId");
+        requireNonNull(request, "request");
         return RetryExecuter.executeWithRetry(() -> {
             return userService
                     .withDeadlineAfter(Environment.defaultConfig().timeout, TimeUnit.MILLISECONDS)
@@ -320,6 +337,7 @@ public class ScalekitUserClient implements UserClient {
      */
     @Override
     public void deleteUserByExternalId(String externalId) {
+        requireNonBlank(externalId, "externalId");
         RetryExecuter.executeWithRetry(() -> {
             DeleteUserRequest request = DeleteUserRequest.newBuilder()
                     .setExternalId(externalId)
@@ -340,6 +358,9 @@ public class ScalekitUserClient implements UserClient {
      */
     @Override
     public CreateMembershipResponse createMembershipByExternalId(String organizationId, String externalId, CreateMembershipRequest request) {
+        requireNonBlank(organizationId, "organizationId");
+        requireNonBlank(externalId, "externalId");
+        requireNonNull(request, "request");
         return RetryExecuter.executeWithRetry(() -> {
             return userService
                     .withDeadlineAfter(Environment.defaultConfig().timeout, TimeUnit.MILLISECONDS)
@@ -357,6 +378,8 @@ public class ScalekitUserClient implements UserClient {
      */
     @Override
     public void deleteMembershipByExternalId(String organizationId, String externalId) {
+        requireNonBlank(organizationId, "organizationId");
+        requireNonBlank(externalId, "externalId");
         RetryExecuter.executeWithRetry(() -> {
             DeleteMembershipRequest request = DeleteMembershipRequest.newBuilder()
                     .setOrganizationId(organizationId)
@@ -378,6 +401,9 @@ public class ScalekitUserClient implements UserClient {
      */
     @Override
     public UpdateMembershipResponse updateMembershipByExternalId(String organizationId, String externalId, UpdateMembershipRequest request) {
+        requireNonBlank(organizationId, "organizationId");
+        requireNonBlank(externalId, "externalId");
+        requireNonNull(request, "request");
         return RetryExecuter.executeWithRetry(() -> {
             return userService
                     .withDeadlineAfter(Environment.defaultConfig().timeout, TimeUnit.MILLISECONDS)

--- a/src/test/java/UserTests.java
+++ b/src/test/java/UserTests.java
@@ -491,6 +491,7 @@ public class UserTests {
                     secondOrg.getId(), externalId,
                     UpdateMembershipRequest.newBuilder().setMembership(updateMembershipPayload).build());
 
+            // immediate response from the update — scoped to secondOrg, identity fields intact
             assertTrue(updateMembershipResp.hasUser());
             User updatedMemberU = updateMembershipResp.getUser();
             assertEquals(userId,    updatedMemberU.getId());
@@ -501,13 +502,22 @@ public class UserTests {
             assertTrue(updatedMemberU.hasUserProfile());
             assertEquals("Bob",  updatedMemberU.getUserProfile().getGivenName());
             assertEquals("Chen", updatedMemberU.getUserProfile().getFamilyName());
-            assertTrue(updatedMemberU.getMembershipsCount() >= 1);
-            OrganizationMembership updatedSecondOrgMembership = updatedMemberU.getMembershipsList().stream()
+
+            // independent lookup — proves Bob still belongs to BOTH orgs after the membership update
+            User freshUser = client.users().getUserByExternalId(externalId).getUser();
+            assertEquals(2, freshUser.getMembershipsCount());
+            OrganizationMembership updatedSecondOrgMembership = freshUser.getMembershipsList().stream()
                     .filter(m -> m.getOrganizationId().equals(secondOrg.getId()))
                     .findFirst()
                     .orElse(null);
             assertNotNull(updatedSecondOrgMembership);
             assertEquals(secondOrg.getId(), updatedSecondOrgMembership.getOrganizationId());
+            assertNotEquals(MembershipStatus.Membership_Status_UNSPECIFIED, updatedSecondOrgMembership.getMembershipStatus());
+            OrganizationMembership testOrgMembership = freshUser.getMembershipsList().stream()
+                    .filter(m -> m.getOrganizationId().equals(testOrg))
+                    .findFirst()
+                    .orElse(null);
+            assertNotNull(testOrgMembership);
 
             // deleteMembershipByExternalId — Bob leaves secondOrg; a second delete must fail
             client.users().deleteMembershipByExternalId(secondOrg.getId(), externalId);

--- a/src/test/java/UserTests.java
+++ b/src/test/java/UserTests.java
@@ -1,5 +1,7 @@
 import com.scalekit.ScalekitClient;
 import com.scalekit.exceptions.APIException;
+import com.scalekit.grpc.scalekit.v1.commons.MembershipStatus;
+import com.scalekit.grpc.scalekit.v1.commons.OrganizationMembership;
 import com.scalekit.grpc.scalekit.v1.organizations.CreateOrganization;
 import com.scalekit.grpc.scalekit.v1.organizations.ListOrganizationsResponse;
 import com.scalekit.grpc.scalekit.v1.organizations.Organization;
@@ -279,110 +281,291 @@ public class UserTests {
 
     @Test
     public void testUserExternalIdOperations() {
-        // Create a user with an external ID
-        String externalId = "ext-" + UUID.randomUUID().toString();
-        String userEmail = "ext.id.test+" + UUID.randomUUID().toString() + "@example.com";
-        CreateUser user = CreateUser.newBuilder()
+        // Scenario: Alice Johnson onboards via an external IdP. She has a full profile and user-level metadata.
+        String externalId = "usr_alice_" + UUID.randomUUID();
+        String userEmail = "alice.johnson+" + UUID.randomUUID() + "@example.com";
+
+        CreateUserProfile createProfile = CreateUserProfile.newBuilder()
+                .setGivenName("Alice")
+                .setFamilyName("Johnson")
+                .setName("Alice Johnson")
+                .setLocale("en-US")
+                .setPhoneNumber("+14155550100")
+                .build();
+
+        CreateUser createUser = CreateUser.newBuilder()
                 .setEmail(userEmail)
                 .setExternalId(externalId)
+                .setUserProfile(createProfile)
+                .putMetadata("source", "external-idp")
+                .putMetadata("plan", "enterprise")
                 .build();
 
-        CreateUserAndMembershipRequest createRequest = CreateUserAndMembershipRequest.newBuilder()
-                .setOrganizationId(testOrg)
-                .setSendInvitationEmail(false)
-                .setUser(user)
-                .build();
+        CreateUserAndMembershipResponse created = client.users().createUserAndMembership(testOrg,
+                CreateUserAndMembershipRequest.newBuilder()
+                        .setOrganizationId(testOrg)
+                        .setSendInvitationEmail(false)
+                        .setUser(createUser)
+                        .build());
 
-        CreateUserAndMembershipResponse createdUser = client.users().createUserAndMembership(testOrg, createRequest);
-        String userId = createdUser.getUser().getId();
+        assertTrue(created.hasUser());
+        User createdU = created.getUser();
+        String userId = createdU.getId();
+
+        // creation response — full field-by-field check
+        assertFalse(userId.isEmpty());
+        assertFalse(createdU.getEnvironmentId().isEmpty());
+        assertEquals(userEmail, createdU.getEmail());
+        assertTrue(createdU.hasExternalId());
+        assertEquals(externalId, createdU.getExternalId());
+        assertTrue(createdU.hasCreateTime());
+        assertTrue(createdU.hasUpdateTime());
+        assertTrue(createdU.hasUserProfile());
+        assertEquals("Alice",        createdU.getUserProfile().getGivenName());
+        assertEquals("Johnson",      createdU.getUserProfile().getFamilyName());
+        assertEquals("Alice Johnson", createdU.getUserProfile().getName());
+        assertEquals("en-US",        createdU.getUserProfile().getLocale());
+        assertEquals("+14155550100", createdU.getUserProfile().getPhoneNumber());
+        assertEquals("external-idp", createdU.getMetadataOrThrow("source"));
+        assertEquals("enterprise",   createdU.getMetadataOrThrow("plan"));
+        assertEquals(1, createdU.getMembershipsCount());
+        OrganizationMembership initialMembership = createdU.getMemberships(0);
+        assertEquals(testOrg, initialMembership.getOrganizationId());
+        assertTrue(initialMembership.hasJoinTime());
+        assertNotEquals(MembershipStatus.MEMBERSHIP_STATUS_UNSPECIFIED, initialMembership.getMembershipStatus());
 
         try {
-            assertNotNull(createdUser);
-            assertEquals(userEmail, createdUser.getUser().getEmail());
-            assertEquals(externalId, createdUser.getUser().getExternalId());
+            // getUserByExternalId — must resolve to the exact same user with all fields intact
+            GetUserResponse fetched = client.users().getUserByExternalId(externalId);
+            assertTrue(fetched.hasUser());
+            User fetchedU = fetched.getUser();
+            assertEquals(userId,       fetchedU.getId());
+            assertFalse(fetchedU.getEnvironmentId().isEmpty());
+            assertEquals(userEmail,    fetchedU.getEmail());
+            assertTrue(fetchedU.hasExternalId());
+            assertEquals(externalId,   fetchedU.getExternalId());
+            assertTrue(fetchedU.hasCreateTime());
+            assertTrue(fetchedU.hasUpdateTime());
+            assertTrue(fetchedU.hasUserProfile());
+            assertEquals("Alice",        fetchedU.getUserProfile().getGivenName());
+            assertEquals("Johnson",      fetchedU.getUserProfile().getFamilyName());
+            assertEquals("Alice Johnson", fetchedU.getUserProfile().getName());
+            assertEquals("en-US",        fetchedU.getUserProfile().getLocale());
+            assertEquals("+14155550100", fetchedU.getUserProfile().getPhoneNumber());
+            assertEquals("external-idp", fetchedU.getMetadataOrThrow("source"));
+            assertEquals("enterprise",   fetchedU.getMetadataOrThrow("plan"));
+            assertEquals(1, fetchedU.getMembershipsCount());
+            assertEquals(testOrg, fetchedU.getMemberships(0).getOrganizationId());
 
-            // Test getUserByExternalId
-            GetUserResponse fetchedUser = client.users().getUserByExternalId(externalId);
-            assertNotNull(fetchedUser);
-            assertEquals(userId, fetchedUser.getUser().getId());
-            assertEquals(externalId, fetchedUser.getUser().getExternalId());
-
-            // Test updateUserByExternalId
+            // updateUserByExternalId — Alice marries and changes her surname, moves to UK, updates her plan
             UpdateUserProfile updatedProfile = UpdateUserProfile.newBuilder()
-                    .setFirstName("ExternalId")
-                    .setLastName("Test")
+                    .setGivenName("Alice")
+                    .setFamilyName("Smith")
+                    .setName("Alice Smith")
+                    .setLocale("en-GB")
+                    .setPhoneNumber("+442071234567")
                     .build();
-            UpdateUser updateUser = UpdateUser.newBuilder()
-                    .setUserProfile(updatedProfile)
-                    .build();
-            UpdateUserRequest updateRequest = UpdateUserRequest.newBuilder()
-                    .setUser(updateUser)
-                    .build();
-            UpdateUserResponse updatedUser = client.users().updateUserByExternalId(externalId, updateRequest);
-            assertNotNull(updatedUser);
-            assertEquals("ExternalId", updatedUser.getUser().getUserProfile().getFirstName());
-            assertEquals("Test", updatedUser.getUser().getUserProfile().getLastName());
-        } finally {
-            // Test deleteUserByExternalId (cleanup)
+            UpdateUserResponse updated = client.users().updateUserByExternalId(externalId,
+                    UpdateUserRequest.newBuilder()
+                            .setUser(UpdateUser.newBuilder()
+                                    .setUserProfile(updatedProfile)
+                                    .putMetadata("plan", "enterprise-plus")
+                                    .build())
+                            .build());
+
+            assertTrue(updated.hasUser());
+            User updatedU = updated.getUser();
+            assertEquals(userId,    updatedU.getId());
+            assertFalse(updatedU.getEnvironmentId().isEmpty());
+            assertEquals(userEmail, updatedU.getEmail());
+            assertTrue(updatedU.hasExternalId());
+            assertEquals(externalId, updatedU.getExternalId());
+            assertTrue(updatedU.hasCreateTime());
+            assertTrue(updatedU.hasUpdateTime());
+            assertTrue(updatedU.hasUserProfile());
+            assertEquals("Alice",           updatedU.getUserProfile().getGivenName());
+            assertEquals("Smith",           updatedU.getUserProfile().getFamilyName());
+            assertEquals("Alice Smith",     updatedU.getUserProfile().getName());
+            assertEquals("en-GB",           updatedU.getUserProfile().getLocale());
+            assertEquals("+442071234567",   updatedU.getUserProfile().getPhoneNumber());
+            assertEquals("enterprise-plus", updatedU.getMetadataOrThrow("plan"));
+
+            // deleteUserByExternalId — user must no longer be retrievable afterwards
             client.users().deleteUserByExternalId(externalId);
+            assertThrows(APIException.class, () -> client.users().getUserByExternalId(externalId));
+        } finally {
+            try { client.users().deleteUser(userId); } catch (Exception ignored) {}
         }
     }
 
     @Test
     public void testMembershipExternalIdOperations() {
-        // Create a user with an external ID
-        String externalId = "ext-mem-" + UUID.randomUUID().toString();
-        String userEmail = "ext.mem.test+" + UUID.randomUUID().toString() + "@example.com";
-        CreateUser user = CreateUser.newBuilder()
+        // Scenario: Bob Chen is a developer who first joins testOrg, then is added to a second org.
+        String externalId = "usr_bob_" + UUID.randomUUID();
+        String userEmail = "bob.chen+" + UUID.randomUUID() + "@example.com";
+
+        CreateUserProfile createProfile = CreateUserProfile.newBuilder()
+                .setGivenName("Bob")
+                .setFamilyName("Chen")
+                .setName("Bob Chen")
+                .setLocale("en-US")
+                .setPhoneNumber("+16505550200")
+                .build();
+
+        CreateUser createUser = CreateUser.newBuilder()
                 .setEmail(userEmail)
                 .setExternalId(externalId)
+                .setUserProfile(createProfile)
+                .putMetadata("department", "engineering")
                 .build();
 
-        CreateUserAndMembershipRequest createRequest = CreateUserAndMembershipRequest.newBuilder()
-                .setOrganizationId(testOrg)
-                .setSendInvitationEmail(false)
-                .setUser(user)
-                .build();
+        CreateUserAndMembershipResponse created = client.users().createUserAndMembership(testOrg,
+                CreateUserAndMembershipRequest.newBuilder()
+                        .setOrganizationId(testOrg)
+                        .setSendInvitationEmail(false)
+                        .setUser(createUser)
+                        .build());
 
-        CreateUserAndMembershipResponse createdUser = client.users().createUserAndMembership(testOrg, createRequest);
-        String userId = createdUser.getUser().getId();
+        assertTrue(created.hasUser());
+        User createdU = created.getUser();
+        String userId = createdU.getId();
+        assertFalse(userId.isEmpty());
+        assertFalse(createdU.getEnvironmentId().isEmpty());
+        assertEquals(userEmail, createdU.getEmail());
+        assertTrue(createdU.hasExternalId());
+        assertEquals(externalId, createdU.getExternalId());
+        assertTrue(createdU.hasCreateTime());
+        assertTrue(createdU.hasUpdateTime());
+        assertTrue(createdU.hasUserProfile());
+        assertEquals("Bob",      createdU.getUserProfile().getGivenName());
+        assertEquals("Chen",     createdU.getUserProfile().getFamilyName());
+        assertEquals("Bob Chen", createdU.getUserProfile().getName());
+        assertEquals("en-US",    createdU.getUserProfile().getLocale());
+        assertEquals("+16505550200", createdU.getUserProfile().getPhoneNumber());
+        assertEquals("engineering", createdU.getMetadataOrThrow("department"));
+        assertEquals(1, createdU.getMembershipsCount());
+        assertEquals(testOrg, createdU.getMemberships(0).getOrganizationId());
 
-        // Create a second organization to test cross-org membership operations
         Organization secondOrg = client.organizations().create(
                 CreateOrganization.newBuilder()
-                        .setDisplayName("External ID Membership Test Org")
+                        .setDisplayName("Bob Chen Second Org")
                         .build()
         );
 
         try {
-            assertNotNull(createdUser);
-
-            // Test createMembershipByExternalId
-            CreateMembership membership = CreateMembership.newBuilder().build();
-            CreateMembershipRequest membershipRequest = CreateMembershipRequest.newBuilder()
-                    .setMembership(membership)
+            // createMembershipByExternalId — Bob joins secondOrg as a developer
+            CreateMembership membershipPayload = CreateMembership.newBuilder()
+                    .putMetadata("invited_by", "admin@example.com")
+                    .putMetadata("access_level", "developer")
                     .build();
-            CreateMembershipResponse membershipResponse = client.users().createMembershipByExternalId(
-                    secondOrg.getId(), externalId, membershipRequest);
-            assertNotNull(membershipResponse);
-            assertNotNull(membershipResponse.getUser());
+            CreateMembershipResponse membershipResp = client.users().createMembershipByExternalId(
+                    secondOrg.getId(), externalId,
+                    CreateMembershipRequest.newBuilder().setMembership(membershipPayload).build());
 
-            // Test updateMembershipByExternalId
-            UpdateMembership updateMembership = UpdateMembership.newBuilder().build();
-            UpdateMembershipRequest updateMembershipRequest = UpdateMembershipRequest.newBuilder()
-                    .setMembership(updateMembership)
+            assertTrue(membershipResp.hasUser());
+            User memberU = membershipResp.getUser();
+            assertEquals(userId,    memberU.getId());
+            assertFalse(memberU.getEnvironmentId().isEmpty());
+            assertEquals(userEmail, memberU.getEmail());
+            assertTrue(memberU.hasExternalId());
+            assertEquals(externalId, memberU.getExternalId());
+            assertTrue(memberU.hasUserProfile());
+            assertEquals("Bob",      memberU.getUserProfile().getGivenName());
+            assertEquals("Chen",     memberU.getUserProfile().getFamilyName());
+            assertEquals("Bob Chen", memberU.getUserProfile().getName());
+            // now belongs to both testOrg and secondOrg
+            assertTrue(memberU.getMembershipsCount() >= 2);
+            OrganizationMembership secondOrgMembership = memberU.getMembershipsList().stream()
+                    .filter(m -> m.getOrganizationId().equals(secondOrg.getId()))
+                    .findFirst()
+                    .orElse(null);
+            assertNotNull(secondOrgMembership);
+            assertEquals(secondOrg.getId(), secondOrgMembership.getOrganizationId());
+            assertTrue(secondOrgMembership.hasJoinTime());
+            assertNotEquals(MembershipStatus.MEMBERSHIP_STATUS_UNSPECIFIED, secondOrgMembership.getMembershipStatus());
+
+            // updateMembershipByExternalId — Bob gets promoted to senior developer in secondOrg
+            UpdateMembership updateMembershipPayload = UpdateMembership.newBuilder()
+                    .putMetadata("access_level", "senior-developer")
+                    .putMetadata("invited_by", "admin@example.com")
                     .build();
-            UpdateMembershipResponse updateMembershipResponse = client.users().updateMembershipByExternalId(
-                    secondOrg.getId(), externalId, updateMembershipRequest);
-            assertNotNull(updateMembershipResponse);
+            UpdateMembershipResponse updateMembershipResp = client.users().updateMembershipByExternalId(
+                    secondOrg.getId(), externalId,
+                    UpdateMembershipRequest.newBuilder().setMembership(updateMembershipPayload).build());
 
-            // Test deleteMembershipByExternalId
+            assertTrue(updateMembershipResp.hasUser());
+            User updatedMemberU = updateMembershipResp.getUser();
+            assertEquals(userId,    updatedMemberU.getId());
+            assertFalse(updatedMemberU.getEnvironmentId().isEmpty());
+            assertEquals(userEmail, updatedMemberU.getEmail());
+            assertTrue(updatedMemberU.hasExternalId());
+            assertEquals(externalId, updatedMemberU.getExternalId());
+            assertTrue(updatedMemberU.hasUserProfile());
+            assertEquals("Bob",  updatedMemberU.getUserProfile().getGivenName());
+            assertEquals("Chen", updatedMemberU.getUserProfile().getFamilyName());
+            assertTrue(updatedMemberU.getMembershipsCount() >= 2);
+            OrganizationMembership updatedSecondOrgMembership = updatedMemberU.getMembershipsList().stream()
+                    .filter(m -> m.getOrganizationId().equals(secondOrg.getId()))
+                    .findFirst()
+                    .orElse(null);
+            assertNotNull(updatedSecondOrgMembership);
+            assertEquals(secondOrg.getId(), updatedSecondOrgMembership.getOrganizationId());
+
+            // deleteMembershipByExternalId — Bob leaves secondOrg; a second delete must fail
             client.users().deleteMembershipByExternalId(secondOrg.getId(), externalId);
+            assertThrows(APIException.class,
+                    () -> client.users().deleteMembershipByExternalId(secondOrg.getId(), externalId));
         } finally {
-            // Cleanup
-            client.users().deleteUser(userId);
-            client.organizations().deleteById(secondOrg.getId());
+            try { client.users().deleteUser(userId); } catch (Exception ignored) {}
+            try { client.organizations().deleteById(secondOrg.getId()); } catch (Exception ignored) {}
         }
+    }
+
+    @Test
+    public void testExternalIdInputValidation() {
+        UpdateUserRequest dummyUpdateUser = UpdateUserRequest.newBuilder()
+                .setUser(UpdateUser.newBuilder().build())
+                .build();
+        CreateMembershipRequest dummyCreateMembership = CreateMembershipRequest.newBuilder()
+                .setMembership(CreateMembership.newBuilder().build())
+                .build();
+        UpdateMembershipRequest dummyUpdateMembership = UpdateMembershipRequest.newBuilder()
+                .setMembership(UpdateMembership.newBuilder().build())
+                .build();
+
+        // getUserByExternalId
+        assertThrows(IllegalArgumentException.class, () -> client.users().getUserByExternalId(null));
+        assertThrows(IllegalArgumentException.class, () -> client.users().getUserByExternalId(""));
+        assertThrows(IllegalArgumentException.class, () -> client.users().getUserByExternalId("  "));
+
+        // updateUserByExternalId
+        assertThrows(IllegalArgumentException.class, () -> client.users().updateUserByExternalId(null, dummyUpdateUser));
+        assertThrows(IllegalArgumentException.class, () -> client.users().updateUserByExternalId("", dummyUpdateUser));
+        assertThrows(IllegalArgumentException.class, () -> client.users().updateUserByExternalId("ext-id", null));
+
+        // deleteUserByExternalId
+        assertThrows(IllegalArgumentException.class, () -> client.users().deleteUserByExternalId(null));
+        assertThrows(IllegalArgumentException.class, () -> client.users().deleteUserByExternalId(""));
+
+        // createMembershipByExternalId
+        assertThrows(IllegalArgumentException.class, () -> client.users().createMembershipByExternalId(null, "ext-id", dummyCreateMembership));
+        assertThrows(IllegalArgumentException.class, () -> client.users().createMembershipByExternalId("", "ext-id", dummyCreateMembership));
+        assertThrows(IllegalArgumentException.class, () -> client.users().createMembershipByExternalId("org-id", null, dummyCreateMembership));
+        assertThrows(IllegalArgumentException.class, () -> client.users().createMembershipByExternalId("org-id", "", dummyCreateMembership));
+        assertThrows(IllegalArgumentException.class, () -> client.users().createMembershipByExternalId("org-id", "ext-id", null));
+
+        // deleteMembershipByExternalId
+        assertThrows(IllegalArgumentException.class, () -> client.users().deleteMembershipByExternalId(null, "ext-id"));
+        assertThrows(IllegalArgumentException.class, () -> client.users().deleteMembershipByExternalId("", "ext-id"));
+        assertThrows(IllegalArgumentException.class, () -> client.users().deleteMembershipByExternalId("org-id", null));
+        assertThrows(IllegalArgumentException.class, () -> client.users().deleteMembershipByExternalId("org-id", ""));
+
+        // updateMembershipByExternalId
+        assertThrows(IllegalArgumentException.class, () -> client.users().updateMembershipByExternalId(null, "ext-id", dummyUpdateMembership));
+        assertThrows(IllegalArgumentException.class, () -> client.users().updateMembershipByExternalId("", "ext-id", dummyUpdateMembership));
+        assertThrows(IllegalArgumentException.class, () -> client.users().updateMembershipByExternalId("org-id", null, dummyUpdateMembership));
+        assertThrows(IllegalArgumentException.class, () -> client.users().updateMembershipByExternalId("org-id", "", dummyUpdateMembership));
+        assertThrows(IllegalArgumentException.class, () -> client.users().updateMembershipByExternalId("org-id", "ext-id", null));
     }
 
     @Test

--- a/src/test/java/UserTests.java
+++ b/src/test/java/UserTests.java
@@ -331,7 +331,6 @@ public class UserTests {
         assertEquals(1, createdU.getMembershipsCount());
         OrganizationMembership initialMembership = createdU.getMemberships(0);
         assertEquals(testOrg, initialMembership.getOrganizationId());
-        assertTrue(initialMembership.hasJoinTime());
         assertNotEquals(MembershipStatus.Membership_Status_UNSPECIFIED, initialMembership.getMembershipStatus());
 
         try {
@@ -481,7 +480,6 @@ public class UserTests {
                     .orElse(null);
             assertNotNull(secondOrgMembership);
             assertEquals(secondOrg.getId(), secondOrgMembership.getOrganizationId());
-            assertTrue(secondOrgMembership.hasJoinTime());
             assertNotEquals(MembershipStatus.Membership_Status_UNSPECIFIED, secondOrgMembership.getMembershipStatus());
 
             // updateMembershipByExternalId — Bob gets promoted to senior developer in secondOrg
@@ -503,7 +501,7 @@ public class UserTests {
             assertTrue(updatedMemberU.hasUserProfile());
             assertEquals("Bob",  updatedMemberU.getUserProfile().getGivenName());
             assertEquals("Chen", updatedMemberU.getUserProfile().getFamilyName());
-            assertTrue(updatedMemberU.getMembershipsCount() >= 2);
+            assertTrue(updatedMemberU.getMembershipsCount() >= 1);
             OrganizationMembership updatedSecondOrgMembership = updatedMemberU.getMembershipsList().stream()
                     .filter(m -> m.getOrganizationId().equals(secondOrg.getId()))
                     .findFirst()

--- a/src/test/java/UserTests.java
+++ b/src/test/java/UserTests.java
@@ -314,49 +314,57 @@ public class UserTests {
 
         // creation response — full field-by-field check
         assertFalse(userId.isEmpty());
-        assertFalse(createdU.getEnvironmentId().isEmpty());
+        String environmentId = createdU.getEnvironmentId();
+        assertFalse(environmentId.isEmpty());
         assertEquals(userEmail, createdU.getEmail());
         assertTrue(createdU.hasExternalId());
         assertEquals(externalId, createdU.getExternalId());
         assertTrue(createdU.hasCreateTime());
+        assertTrue(createdU.getCreateTime().getSeconds() > 0);
+        long createTimeSeconds = createdU.getCreateTime().getSeconds();
         assertTrue(createdU.hasUpdateTime());
+        assertTrue(createdU.getUpdateTime().getSeconds() > 0);
+        assertTrue(createdU.getUpdateTime().getSeconds() >= createdU.getCreateTime().getSeconds());
         assertTrue(createdU.hasUserProfile());
-        assertEquals("Alice",        createdU.getUserProfile().getGivenName());
-        assertEquals("Johnson",      createdU.getUserProfile().getFamilyName());
+        assertEquals("Alice",         createdU.getUserProfile().getGivenName());
+        assertEquals("Johnson",       createdU.getUserProfile().getFamilyName());
         assertEquals("Alice Johnson", createdU.getUserProfile().getName());
-        assertEquals("en-US",        createdU.getUserProfile().getLocale());
-        assertEquals("+14155550100", createdU.getUserProfile().getPhoneNumber());
-        assertEquals("external-idp", createdU.getMetadataOrThrow("source"));
-        assertEquals("enterprise",   createdU.getMetadataOrThrow("plan"));
+        assertEquals("en-US",         createdU.getUserProfile().getLocale());
+        assertEquals("+14155550100",  createdU.getUserProfile().getPhoneNumber());
+        assertEquals("external-idp",  createdU.getMetadataOrThrow("source"));
+        assertEquals("enterprise",    createdU.getMetadataOrThrow("plan"));
         assertEquals(1, createdU.getMembershipsCount());
         OrganizationMembership initialMembership = createdU.getMemberships(0);
         assertEquals(testOrg, initialMembership.getOrganizationId());
-        assertNotEquals(MembershipStatus.Membership_Status_UNSPECIFIED, initialMembership.getMembershipStatus());
+        assertEquals(MembershipStatus.ACTIVE, initialMembership.getMembershipStatus());
 
         try {
-            // getUserByExternalId — must resolve to the exact same user with all fields intact
+            // getUserByExternalId — must resolve to the exact same user with all fields stable
             GetUserResponse fetched = client.users().getUserByExternalId(externalId);
             assertTrue(fetched.hasUser());
             User fetchedU = fetched.getUser();
-            assertEquals(userId,       fetchedU.getId());
-            assertFalse(fetchedU.getEnvironmentId().isEmpty());
-            assertEquals(userEmail,    fetchedU.getEmail());
+            assertEquals(userId,        fetchedU.getId());
+            assertEquals(environmentId, fetchedU.getEnvironmentId());
+            assertEquals(userEmail,     fetchedU.getEmail());
             assertTrue(fetchedU.hasExternalId());
-            assertEquals(externalId,   fetchedU.getExternalId());
+            assertEquals(externalId,    fetchedU.getExternalId());
             assertTrue(fetchedU.hasCreateTime());
+            assertEquals(createTimeSeconds, fetchedU.getCreateTime().getSeconds());
             assertTrue(fetchedU.hasUpdateTime());
+            assertTrue(fetchedU.getUpdateTime().getSeconds() > 0);
             assertTrue(fetchedU.hasUserProfile());
-            assertEquals("Alice",        fetchedU.getUserProfile().getGivenName());
-            assertEquals("Johnson",      fetchedU.getUserProfile().getFamilyName());
+            assertEquals("Alice",         fetchedU.getUserProfile().getGivenName());
+            assertEquals("Johnson",       fetchedU.getUserProfile().getFamilyName());
             assertEquals("Alice Johnson", fetchedU.getUserProfile().getName());
-            assertEquals("en-US",        fetchedU.getUserProfile().getLocale());
-            assertEquals("+14155550100", fetchedU.getUserProfile().getPhoneNumber());
-            assertEquals("external-idp", fetchedU.getMetadataOrThrow("source"));
-            assertEquals("enterprise",   fetchedU.getMetadataOrThrow("plan"));
+            assertEquals("en-US",         fetchedU.getUserProfile().getLocale());
+            assertEquals("+14155550100",  fetchedU.getUserProfile().getPhoneNumber());
+            assertEquals("external-idp",  fetchedU.getMetadataOrThrow("source"));
+            assertEquals("enterprise",    fetchedU.getMetadataOrThrow("plan"));
             assertEquals(1, fetchedU.getMembershipsCount());
             assertEquals(testOrg, fetchedU.getMemberships(0).getOrganizationId());
+            assertEquals(MembershipStatus.ACTIVE, fetchedU.getMemberships(0).getMembershipStatus());
 
-            // updateUserByExternalId — Alice marries and changes her surname, moves to UK, updates her plan
+            // updateUserByExternalId — Alice marries, changes surname, moves to UK, upgrades plan
             UpdateUserProfile updatedProfile = UpdateUserProfile.newBuilder()
                     .setGivenName("Alice")
                     .setFamilyName("Smith")
@@ -374,13 +382,15 @@ public class UserTests {
 
             assertTrue(updated.hasUser());
             User updatedU = updated.getUser();
-            assertEquals(userId,    updatedU.getId());
-            assertFalse(updatedU.getEnvironmentId().isEmpty());
-            assertEquals(userEmail, updatedU.getEmail());
+            assertEquals(userId,        updatedU.getId());
+            assertEquals(environmentId, updatedU.getEnvironmentId());
+            assertEquals(userEmail,     updatedU.getEmail());
             assertTrue(updatedU.hasExternalId());
-            assertEquals(externalId, updatedU.getExternalId());
+            assertEquals(externalId,    updatedU.getExternalId());
             assertTrue(updatedU.hasCreateTime());
+            assertEquals(createTimeSeconds, updatedU.getCreateTime().getSeconds());
             assertTrue(updatedU.hasUpdateTime());
+            assertTrue(updatedU.getUpdateTime().getSeconds() >= updatedU.getCreateTime().getSeconds());
             assertTrue(updatedU.hasUserProfile());
             assertEquals("Alice",           updatedU.getUserProfile().getGivenName());
             assertEquals("Smith",           updatedU.getUserProfile().getFamilyName());
@@ -388,6 +398,14 @@ public class UserTests {
             assertEquals("en-GB",           updatedU.getUserProfile().getLocale());
             assertEquals("+442071234567",   updatedU.getUserProfile().getPhoneNumber());
             assertEquals("enterprise-plus", updatedU.getMetadataOrThrow("plan"));
+
+            // confirm the update was persisted — a fresh GET must reflect the new values
+            User verifiedU = client.users().getUserByExternalId(externalId).getUser();
+            assertEquals(userId,            verifiedU.getId());
+            assertEquals("Smith",           verifiedU.getUserProfile().getFamilyName());
+            assertEquals("Alice Smith",     verifiedU.getUserProfile().getName());
+            assertEquals("en-GB",           verifiedU.getUserProfile().getLocale());
+            assertEquals("enterprise-plus", verifiedU.getMetadataOrThrow("plan"));
 
             // deleteUserByExternalId — user must no longer be retrievable afterwards
             client.users().deleteUserByExternalId(externalId);
@@ -429,21 +447,26 @@ public class UserTests {
         User createdU = created.getUser();
         String userId = createdU.getId();
         assertFalse(userId.isEmpty());
-        assertFalse(createdU.getEnvironmentId().isEmpty());
+        String environmentId = createdU.getEnvironmentId();
+        assertFalse(environmentId.isEmpty());
         assertEquals(userEmail, createdU.getEmail());
         assertTrue(createdU.hasExternalId());
         assertEquals(externalId, createdU.getExternalId());
         assertTrue(createdU.hasCreateTime());
+        assertTrue(createdU.getCreateTime().getSeconds() > 0);
+        long createTimeSeconds = createdU.getCreateTime().getSeconds();
         assertTrue(createdU.hasUpdateTime());
+        assertTrue(createdU.getUpdateTime().getSeconds() > 0);
         assertTrue(createdU.hasUserProfile());
-        assertEquals("Bob",      createdU.getUserProfile().getGivenName());
-        assertEquals("Chen",     createdU.getUserProfile().getFamilyName());
-        assertEquals("Bob Chen", createdU.getUserProfile().getName());
-        assertEquals("en-US",    createdU.getUserProfile().getLocale());
+        assertEquals("Bob",          createdU.getUserProfile().getGivenName());
+        assertEquals("Chen",         createdU.getUserProfile().getFamilyName());
+        assertEquals("Bob Chen",     createdU.getUserProfile().getName());
+        assertEquals("en-US",        createdU.getUserProfile().getLocale());
         assertEquals("+16505550200", createdU.getUserProfile().getPhoneNumber());
-        assertEquals("engineering", createdU.getMetadataOrThrow("department"));
+        assertEquals("engineering",  createdU.getMetadataOrThrow("department"));
         assertEquals(1, createdU.getMembershipsCount());
         assertEquals(testOrg, createdU.getMemberships(0).getOrganizationId());
+        assertEquals(MembershipStatus.ACTIVE, createdU.getMemberships(0).getMembershipStatus());
 
         Organization secondOrg = client.organizations().create(
                 CreateOrganization.newBuilder()
@@ -452,7 +475,7 @@ public class UserTests {
         );
 
         try {
-            // createMembershipByExternalId — Bob joins secondOrg as a developer
+            // createMembershipByExternalId — Bob joins secondOrg; response must show both memberships
             CreateMembership membershipPayload = CreateMembership.newBuilder()
                     .putMetadata("invited_by", "admin@example.com")
                     .putMetadata("access_level", "developer")
@@ -463,66 +486,76 @@ public class UserTests {
 
             assertTrue(membershipResp.hasUser());
             User memberU = membershipResp.getUser();
-            assertEquals(userId,    memberU.getId());
-            assertFalse(memberU.getEnvironmentId().isEmpty());
-            assertEquals(userEmail, memberU.getEmail());
+            assertEquals(userId,        memberU.getId());
+            assertEquals(environmentId, memberU.getEnvironmentId());
+            assertEquals(userEmail,     memberU.getEmail());
             assertTrue(memberU.hasExternalId());
-            assertEquals(externalId, memberU.getExternalId());
+            assertEquals(externalId,    memberU.getExternalId());
             assertTrue(memberU.hasUserProfile());
             assertEquals("Bob",      memberU.getUserProfile().getGivenName());
             assertEquals("Chen",     memberU.getUserProfile().getFamilyName());
             assertEquals("Bob Chen", memberU.getUserProfile().getName());
-            // now belongs to both testOrg and secondOrg
-            assertTrue(memberU.getMembershipsCount() >= 2);
+            assertEquals(2, memberU.getMembershipsCount());
             OrganizationMembership secondOrgMembership = memberU.getMembershipsList().stream()
                     .filter(m -> m.getOrganizationId().equals(secondOrg.getId()))
                     .findFirst()
                     .orElse(null);
             assertNotNull(secondOrgMembership);
             assertEquals(secondOrg.getId(), secondOrgMembership.getOrganizationId());
-            assertNotEquals(MembershipStatus.Membership_Status_UNSPECIFIED, secondOrgMembership.getMembershipStatus());
+            // createMembershipByExternalId has no sendInvitationEmail=false option,
+            // so the server always creates cross-org memberships as PENDING_INVITE
+            assertEquals(MembershipStatus.PENDING_INVITE, secondOrgMembership.getMembershipStatus());
 
             // updateMembershipByExternalId — Bob gets promoted to senior developer in secondOrg
-            UpdateMembership updateMembershipPayload = UpdateMembership.newBuilder()
-                    .putMetadata("access_level", "senior-developer")
-                    .putMetadata("invited_by", "admin@example.com")
-                    .build();
             UpdateMembershipResponse updateMembershipResp = client.users().updateMembershipByExternalId(
                     secondOrg.getId(), externalId,
-                    UpdateMembershipRequest.newBuilder().setMembership(updateMembershipPayload).build());
+                    UpdateMembershipRequest.newBuilder()
+                            .setMembership(UpdateMembership.newBuilder()
+                                    .putMetadata("access_level", "senior-developer")
+                                    .putMetadata("invited_by", "admin@example.com")
+                                    .build())
+                            .build());
 
-            // immediate response from the update — scoped to secondOrg, identity fields intact
+            // immediate response — scoped to secondOrg; verify identity fields are intact
             assertTrue(updateMembershipResp.hasUser());
             User updatedMemberU = updateMembershipResp.getUser();
-            assertEquals(userId,    updatedMemberU.getId());
-            assertFalse(updatedMemberU.getEnvironmentId().isEmpty());
-            assertEquals(userEmail, updatedMemberU.getEmail());
+            assertEquals(userId,        updatedMemberU.getId());
+            assertEquals(environmentId, updatedMemberU.getEnvironmentId());
+            assertEquals(userEmail,     updatedMemberU.getEmail());
             assertTrue(updatedMemberU.hasExternalId());
-            assertEquals(externalId, updatedMemberU.getExternalId());
+            assertEquals(externalId,    updatedMemberU.getExternalId());
             assertTrue(updatedMemberU.hasUserProfile());
             assertEquals("Bob",  updatedMemberU.getUserProfile().getGivenName());
             assertEquals("Chen", updatedMemberU.getUserProfile().getFamilyName());
 
-            // independent lookup — proves Bob still belongs to BOTH orgs after the membership update
+            // independent lookup — Bob must still belong to BOTH orgs with ACTIVE status in each
             User freshUser = client.users().getUserByExternalId(externalId).getUser();
+            assertEquals(userId,        freshUser.getId());
+            assertEquals(environmentId, freshUser.getEnvironmentId());
             assertEquals(2, freshUser.getMembershipsCount());
-            OrganizationMembership updatedSecondOrgMembership = freshUser.getMembershipsList().stream()
+            OrganizationMembership freshSecondOrg = freshUser.getMembershipsList().stream()
                     .filter(m -> m.getOrganizationId().equals(secondOrg.getId()))
-                    .findFirst()
-                    .orElse(null);
-            assertNotNull(updatedSecondOrgMembership);
-            assertEquals(secondOrg.getId(), updatedSecondOrgMembership.getOrganizationId());
-            assertNotEquals(MembershipStatus.Membership_Status_UNSPECIFIED, updatedSecondOrgMembership.getMembershipStatus());
-            OrganizationMembership testOrgMembership = freshUser.getMembershipsList().stream()
+                    .findFirst().orElse(null);
+            assertNotNull(freshSecondOrg);
+            assertEquals(secondOrg.getId(), freshSecondOrg.getOrganizationId());
+            assertEquals(MembershipStatus.PENDING_INVITE, freshSecondOrg.getMembershipStatus());
+            OrganizationMembership freshTestOrg = freshUser.getMembershipsList().stream()
                     .filter(m -> m.getOrganizationId().equals(testOrg))
-                    .findFirst()
-                    .orElse(null);
-            assertNotNull(testOrgMembership);
+                    .findFirst().orElse(null);
+            assertNotNull(freshTestOrg);
+            assertEquals(testOrg, freshTestOrg.getOrganizationId());
+            assertEquals(MembershipStatus.ACTIVE, freshTestOrg.getMembershipStatus());
 
-            // deleteMembershipByExternalId — Bob leaves secondOrg; a second delete must fail
+            // deleteMembershipByExternalId — Bob leaves secondOrg
             client.users().deleteMembershipByExternalId(secondOrg.getId(), externalId);
+            // re-delete must fail — membership is gone
             assertThrows(APIException.class,
                     () -> client.users().deleteMembershipByExternalId(secondOrg.getId(), externalId));
+            // fresh lookup must show Bob belongs to exactly testOrg only
+            User afterDeleteUser = client.users().getUserByExternalId(externalId).getUser();
+            assertEquals(1, afterDeleteUser.getMembershipsCount());
+            assertEquals(testOrg, afterDeleteUser.getMemberships(0).getOrganizationId());
+            assertEquals(MembershipStatus.ACTIVE, afterDeleteUser.getMemberships(0).getMembershipStatus());
         } finally {
             try { client.users().deleteUser(userId); } catch (Exception ignored) {}
             try { client.organizations().deleteById(secondOrg.getId()); } catch (Exception ignored) {}

--- a/src/test/java/UserTests.java
+++ b/src/test/java/UserTests.java
@@ -332,7 +332,7 @@ public class UserTests {
         OrganizationMembership initialMembership = createdU.getMemberships(0);
         assertEquals(testOrg, initialMembership.getOrganizationId());
         assertTrue(initialMembership.hasJoinTime());
-        assertNotEquals(MembershipStatus.MEMBERSHIP_STATUS_UNSPECIFIED, initialMembership.getMembershipStatus());
+        assertNotEquals(MembershipStatus.Membership_Status_UNSPECIFIED, initialMembership.getMembershipStatus());
 
         try {
             // getUserByExternalId — must resolve to the exact same user with all fields intact
@@ -482,7 +482,7 @@ public class UserTests {
             assertNotNull(secondOrgMembership);
             assertEquals(secondOrg.getId(), secondOrgMembership.getOrganizationId());
             assertTrue(secondOrgMembership.hasJoinTime());
-            assertNotEquals(MembershipStatus.MEMBERSHIP_STATUS_UNSPECIFIED, secondOrgMembership.getMembershipStatus());
+            assertNotEquals(MembershipStatus.Membership_Status_UNSPECIFIED, secondOrgMembership.getMembershipStatus());
 
             // updateMembershipByExternalId — Bob gets promoted to senior developer in secondOrg
             UpdateMembership updateMembershipPayload = UpdateMembership.newBuilder()

--- a/src/test/java/UserTests.java
+++ b/src/test/java/UserTests.java
@@ -276,6 +276,112 @@ public class UserTests {
     }
 
     @Test
+    public void testUserExternalIdOperations() {
+        // Create a user with an external ID
+        String externalId = "ext-" + System.currentTimeMillis();
+        String userEmail = "ext.id.test" + System.currentTimeMillis() + "@example.com";
+        CreateUser user = CreateUser.newBuilder()
+                .setEmail(userEmail)
+                .setExternalId(externalId)
+                .build();
+
+        CreateUserAndMembershipRequest createRequest = CreateUserAndMembershipRequest.newBuilder()
+                .setOrganizationId(testOrg)
+                .setSendInvitationEmail(false)
+                .setUser(user)
+                .build();
+
+        CreateUserAndMembershipResponse createdUser = client.users().createUserAndMembership(testOrg, createRequest);
+        assertNotNull(createdUser);
+        assertEquals(userEmail, createdUser.getUser().getEmail());
+        assertEquals(externalId, createdUser.getUser().getExternalId());
+        String userId = createdUser.getUser().getId();
+
+        try {
+            // Test getUserByExternalId
+            GetUserResponse fetchedUser = client.users().getUserByExternalId(externalId);
+            assertNotNull(fetchedUser);
+            assertEquals(userId, fetchedUser.getUser().getId());
+            assertEquals(externalId, fetchedUser.getUser().getExternalId());
+
+            // Test updateUserByExternalId
+            UpdateUserProfile updatedProfile = UpdateUserProfile.newBuilder()
+                    .setFirstName("ExternalId")
+                    .setLastName("Test")
+                    .build();
+            UpdateUser updateUser = UpdateUser.newBuilder()
+                    .setUserProfile(updatedProfile)
+                    .build();
+            UpdateUserRequest updateRequest = UpdateUserRequest.newBuilder()
+                    .setUser(updateUser)
+                    .build();
+            UpdateUserResponse updatedUser = client.users().updateUserByExternalId(externalId, updateRequest);
+            assertNotNull(updatedUser);
+            assertEquals("ExternalId", updatedUser.getUser().getUserProfile().getFirstName());
+            assertEquals("Test", updatedUser.getUser().getUserProfile().getLastName());
+        } finally {
+            // Test deleteUserByExternalId (cleanup)
+            client.users().deleteUserByExternalId(externalId);
+        }
+    }
+
+    @Test
+    public void testMembershipExternalIdOperations() {
+        // Create a user with an external ID
+        String externalId = "ext-mem-" + System.currentTimeMillis();
+        String userEmail = "ext.mem.test" + System.currentTimeMillis() + "@example.com";
+        CreateUser user = CreateUser.newBuilder()
+                .setEmail(userEmail)
+                .setExternalId(externalId)
+                .build();
+
+        CreateUserAndMembershipRequest createRequest = CreateUserAndMembershipRequest.newBuilder()
+                .setOrganizationId(testOrg)
+                .setSendInvitationEmail(false)
+                .setUser(user)
+                .build();
+
+        CreateUserAndMembershipResponse createdUser = client.users().createUserAndMembership(testOrg, createRequest);
+        assertNotNull(createdUser);
+        String userId = createdUser.getUser().getId();
+
+        // Create a second organization to test cross-org membership operations
+        Organization secondOrg = client.organizations().create(
+                CreateOrganization.newBuilder()
+                        .setDisplayName("External ID Membership Test Org")
+                        .build()
+        );
+
+        try {
+            // Test createMembershipByExternalId
+            CreateMembership membership = CreateMembership.newBuilder().build();
+            CreateMembershipRequest membershipRequest = CreateMembershipRequest.newBuilder()
+                    .setMembership(membership)
+                    .build();
+            CreateMembershipResponse membershipResponse = client.users().createMembershipByExternalId(
+                    secondOrg.getId(), externalId, membershipRequest);
+            assertNotNull(membershipResponse);
+            assertNotNull(membershipResponse.getUser());
+
+            // Test updateMembershipByExternalId
+            UpdateMembership updateMembership = UpdateMembership.newBuilder().build();
+            UpdateMembershipRequest updateMembershipRequest = UpdateMembershipRequest.newBuilder()
+                    .setMembership(updateMembership)
+                    .build();
+            UpdateMembershipResponse updateMembershipResponse = client.users().updateMembershipByExternalId(
+                    secondOrg.getId(), externalId, updateMembershipRequest);
+            assertNotNull(updateMembershipResponse);
+
+            // Test deleteMembershipByExternalId
+            client.users().deleteMembershipByExternalId(secondOrg.getId(), externalId);
+        } finally {
+            // Cleanup
+            client.users().deleteUser(userId);
+            client.organizations().deleteById(secondOrg.getId());
+        }
+    }
+
+    @Test
     public void testResendInvite() {
         // Create a user with invitation email
         String userEmail = "resend.invite.test" + System.currentTimeMillis() + "@example.com";

--- a/src/test/java/UserTests.java
+++ b/src/test/java/UserTests.java
@@ -7,6 +7,8 @@ import com.scalekit.grpc.scalekit.v1.users.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class UserTests {
@@ -278,8 +280,8 @@ public class UserTests {
     @Test
     public void testUserExternalIdOperations() {
         // Create a user with an external ID
-        String externalId = "ext-" + System.currentTimeMillis();
-        String userEmail = "ext.id.test" + System.currentTimeMillis() + "@example.com";
+        String externalId = "ext-" + UUID.randomUUID().toString();
+        String userEmail = "ext.id.test+" + UUID.randomUUID().toString() + "@example.com";
         CreateUser user = CreateUser.newBuilder()
                 .setEmail(userEmail)
                 .setExternalId(externalId)
@@ -292,12 +294,13 @@ public class UserTests {
                 .build();
 
         CreateUserAndMembershipResponse createdUser = client.users().createUserAndMembership(testOrg, createRequest);
-        assertNotNull(createdUser);
-        assertEquals(userEmail, createdUser.getUser().getEmail());
-        assertEquals(externalId, createdUser.getUser().getExternalId());
         String userId = createdUser.getUser().getId();
 
         try {
+            assertNotNull(createdUser);
+            assertEquals(userEmail, createdUser.getUser().getEmail());
+            assertEquals(externalId, createdUser.getUser().getExternalId());
+
             // Test getUserByExternalId
             GetUserResponse fetchedUser = client.users().getUserByExternalId(externalId);
             assertNotNull(fetchedUser);
@@ -328,8 +331,8 @@ public class UserTests {
     @Test
     public void testMembershipExternalIdOperations() {
         // Create a user with an external ID
-        String externalId = "ext-mem-" + System.currentTimeMillis();
-        String userEmail = "ext.mem.test" + System.currentTimeMillis() + "@example.com";
+        String externalId = "ext-mem-" + UUID.randomUUID().toString();
+        String userEmail = "ext.mem.test+" + UUID.randomUUID().toString() + "@example.com";
         CreateUser user = CreateUser.newBuilder()
                 .setEmail(userEmail)
                 .setExternalId(externalId)
@@ -342,7 +345,6 @@ public class UserTests {
                 .build();
 
         CreateUserAndMembershipResponse createdUser = client.users().createUserAndMembership(testOrg, createRequest);
-        assertNotNull(createdUser);
         String userId = createdUser.getUser().getId();
 
         // Create a second organization to test cross-org membership operations
@@ -353,6 +355,8 @@ public class UserTests {
         );
 
         try {
+            assertNotNull(createdUser);
+
             // Test createMembershipByExternalId
             CreateMembership membership = CreateMembership.newBuilder().build();
             CreateMembershipRequest membershipRequest = CreateMembershipRequest.newBuilder()


### PR DESCRIPTION
## Summary

Adds 6 new methods to `UserClient` (interface) and `ScalekitUserClient` (implementation) to support looking up and managing users and memberships by `external_id`, mirroring the backend REST bindings added in scalekit-inc/scalekit#2283.

**New user methods:**
- `getUserByExternalId(String externalId)` — fetch a user by external ID
- `updateUserByExternalId(String externalId, UpdateUserRequest request)` — update a user by external ID
- `deleteUserByExternalId(String externalId)` — delete a user by external ID

**New membership methods:**
- `createMembershipByExternalId(String organizationId, String externalId, CreateMembershipRequest request)` — add a user (by external ID) to an organization
- `deleteMembershipByExternalId(String organizationId, String externalId)` — remove a user (by external ID) from an organization
- `updateMembershipByExternalId(String organizationId, String externalId, UpdateMembershipRequest request)` — update a user's membership by external ID

All implementations follow the same `RetryExecuter.executeWithRetry` pattern as existing methods, using `setExternalId(externalId)` in the request builder instead of `setId(userId)`.

## Test plan

- [ ] `testUserExternalIdOperations` — creates a user with `externalId`, exercises `getUserByExternalId`, `updateUserByExternalId`, and `deleteUserByExternalId`
- [ ] `testMembershipExternalIdOperations` — creates a user with `externalId`, exercises `createMembershipByExternalId`, `updateMembershipByExternalId`, and `deleteMembershipByExternalId` against a second org
- [ ] `mvn compile -q` — verifies no compile errors on main and test sources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added external ID–based user operations to retrieve, update, and delete a user by external identifier.
  * Added external ID–based membership operations within an organization to create, update, and delete membership using the external user identifier.
* **Bug Fixes**
  * Fail-fast validation for external ID inputs, including null and blank values, across the new operations.
* **Tests**
  * Added end-to-end tests covering external ID user/membership CRUD flows and negative-case input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->