### PR TITLE
Add AuditLogs client and Events.listEvents

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -17,6 +17,7 @@
 - [Tokens](#tokens)
 - [M2M](#m2m)
 - [Events](#events)
+- [Audit Logs](#audit-logs)
 
 The Java SDK exposes the clients and methods in the sections above through `ScalekitClient`. Connected Accounts, Tools, and Actions are not part of the Java public API in this release.
 
@@ -7669,6 +7670,207 @@ ListEventsPaginatedResponse response = client.events().listEventsPaginated(filte
 <dd>
 
 **pageToken:** `String` - Pagination cursor (null or empty string for the first page)
+
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+<details><summary><code>client.events().<a href="https://github.com/scalekit-inc/scalekit-sdk-java/blob/main/src/main/java/com/scalekit/api/EventsClient.java">listEvents</a>(pageSize, pageToken) -> ListEventsResponse</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+Lists environment events matching an empty filter, most-recent first, including a total count of matching events.
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```java
+ListEventsResponse response = client.events().listEvents(10, "");
+System.out.println("Total events: " + response.getTotalSize());
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**pageSize:** `int` - Number of events per page (defaults to 10 when <= 0)
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**pageToken:** `String` - Pagination cursor (null or empty string for the first page)
+
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+<details><summary><code>client.events().<a href="https://github.com/scalekit-inc/scalekit-sdk-java/blob/main/src/main/java/com/scalekit/api/EventsClient.java">listEvents</a>(filter, pageSize, pageToken) -> ListEventsResponse</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+Lists environment events matching an `EventFilter`, most-recent first, including a total count of matching events. Set `EventFilter.setAuthRequestId(...)` to see every event a specific authentication request produced — correlate it with the `authRequestId` returned by `client.auditLogs().listAuthRequests`.
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```java
+EventFilter filter = EventFilter.newBuilder()
+  .setAuthRequestId("areq_123456")
+  .build();
+
+ListEventsResponse response = client.events().listEvents(filter, 10, "");
+System.out.println("Total events: " + response.getTotalSize());
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**filter:** `EventFilter` - Filter criteria (event types, organization ID, time range, source, auth_request_id, interceptor/connection/connected-account IDs)
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**pageSize:** `int` - Number of events per page (defaults to 10 when <= 0)
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**pageToken:** `String` - Pagination cursor (null or empty string for the first page)
+
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+## Audit Logs
+
+<details><summary><code>client.auditLogs().<a href="https://github.com/scalekit-inc/scalekit-sdk-java/blob/main/src/main/java/com/scalekit/api/AuditLogsClient.java">listAuthRequests</a>(request) -> ListAuthLogResponse</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+Lists authentication request logs for the current environment, ordered most-recent first. Each entry's `authRequestId` can be passed to `client.events().listEvents`'s `EventFilter.setAuthRequestId` to see every event a specific login produced.
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```java
+ListAuthLogRequest request = ListAuthLogRequest.newBuilder()
+  .setEmail("jane.doe@example.com")
+  .setPageSize(10)
+  .build();
+
+ListAuthLogResponse response = client.auditLogs().listAuthRequests(request);
+response.getAuthRequestsList().forEach(entry ->
+  System.out.println(entry.getAuthRequestId() + " - " + entry.getStatus()));
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**request:** `ListAuthLogRequest` - Filter and pagination options (pageSize, pageToken, email, status, startTime, endTime, resourceId, connectedAccountIdentifier, clientId)
 
 </dd>
 </dl>

--- a/src/main/java/com/scalekit/ScalekitClient.java
+++ b/src/main/java/com/scalekit/ScalekitClient.java
@@ -46,6 +46,8 @@ public class ScalekitClient {
 
     private final EventsClient eventsClient;
 
+    private final AuditLogsClient auditLogsClient;
+
     public ScalekitClient(String siteName, String clientId, String clientSecret) {
 
         Environment.configure(siteName,clientId,clientSecret);
@@ -78,6 +80,7 @@ public class ScalekitClient {
             tokenClient = new ScalekitTokenClient(channel, credentials);
             m2mClient = new ScalekitM2MClient(channel, credentials);
             eventsClient = new ScalekitEventsClient(channel, credentials);
+            auditLogsClient = new ScalekitAuditLogsClient(channel, credentials);
             webhook = new ScalekitWebhook();
 
         } catch (MalformedURLException e) {
@@ -146,5 +149,9 @@ public class ScalekitClient {
 
     public EventsClient events() {
         return this.eventsClient;
+    }
+
+    public AuditLogsClient auditLogs() {
+        return this.auditLogsClient;
     }
 }

--- a/src/main/java/com/scalekit/api/AuditLogsClient.java
+++ b/src/main/java/com/scalekit/api/AuditLogsClient.java
@@ -1,0 +1,9 @@
+package com.scalekit.api;
+
+import com.scalekit.grpc.scalekit.v1.auditlogs.*;
+
+public interface AuditLogsClient {
+
+  ListAuthLogResponse listAuthRequests(ListAuthLogRequest request);
+
+}

--- a/src/main/java/com/scalekit/api/EventsClient.java
+++ b/src/main/java/com/scalekit/api/EventsClient.java
@@ -8,4 +8,8 @@ public interface EventsClient {
 
   ListEventsPaginatedResponse listEventsPaginated(EventFilter filter, int pageSize, String pageToken);
 
+  ListEventsResponse listEvents(int pageSize, String pageToken);
+
+  ListEventsResponse listEvents(EventFilter filter, int pageSize, String pageToken);
+
 }

--- a/src/main/java/com/scalekit/api/impl/ScalekitAuditLogsClient.java
+++ b/src/main/java/com/scalekit/api/impl/ScalekitAuditLogsClient.java
@@ -1,0 +1,44 @@
+package com.scalekit.api.impl;
+
+import com.scalekit.Environment;
+import com.scalekit.api.AuditLogsClient;
+import com.scalekit.grpc.scalekit.v1.auditlogs.*;
+import com.scalekit.internal.RetryExecuter;
+import com.scalekit.internal.ScalekitCredentials;
+import io.grpc.ManagedChannel;
+import io.grpc.StatusRuntimeException;
+
+import java.util.concurrent.TimeUnit;
+
+public class ScalekitAuditLogsClient implements AuditLogsClient {
+
+    private final AuditLogsServiceGrpc.AuditLogsServiceBlockingStub auditLogsStub;
+    private final ScalekitCredentials credentials;
+
+    public ScalekitAuditLogsClient(ManagedChannel channel, ScalekitCredentials credentials) {
+        try {
+            this.credentials = credentials;
+            this.auditLogsStub = AuditLogsServiceGrpc
+                    .newBlockingStub(channel)
+                    .withCallCredentials(this.credentials);
+        } catch (StatusRuntimeException e) {
+            throw new RuntimeException("Error creating AuditLogs client", e);
+        }
+    }
+
+    /**
+     * Lists authentication request logs for the current environment, ordered most-recent first.
+     * Each entry's authRequestId can be passed to EventsClient.listEvents via
+     * EventFilter.setAuthRequestId to see every event a specific login produced.
+     * @param request: The list authentication request logs request containing filters and pagination options
+     * @return ListAuthLogResponse: The response containing the log entries and pagination info
+     */
+    @Override
+    public ListAuthLogResponse listAuthRequests(ListAuthLogRequest request) {
+        return RetryExecuter.executeWithRetry(() -> {
+            return auditLogsStub
+                    .withDeadlineAfter(Environment.defaultConfig().timeout, TimeUnit.MILLISECONDS)
+                    .listAuthRequests(request);
+        }, this.credentials);
+    }
+}

--- a/src/main/java/com/scalekit/api/impl/ScalekitEventsClient.java
+++ b/src/main/java/com/scalekit/api/impl/ScalekitEventsClient.java
@@ -76,4 +76,50 @@ public class ScalekitEventsClient implements EventsClient {
         },this.credentials);
     }
 
+    /**
+     * listEvents retrieves a list of events matching an empty filter, including a total count
+     * <p>
+     * @param pageSize: The number of events to retrieve default page size is 10
+     * @param pageToken: The page token to retrieve the next page
+     * @return ListEventsResponse: The list of events retrieved, including total_size
+     */
+    @Override
+    public ListEventsResponse listEvents(int pageSize, String pageToken) {
+        return listEvents(EventFilter.newBuilder().build(), pageSize, pageToken);
+    }
+
+    /**
+     * listEvents retrieves a list of events matching the given filter, including a total count.
+     * Set {@link EventFilter#getAuthRequestId()} to correlate results with a specific
+     * authentication request returned by AuditLogsClient.listAuthRequests.
+     * <p>
+     * @param filter: The filter to apply when listing events
+     * @param pageSize: The number of events to retrieve default page size is 10
+     * @param pageToken: The page token to retrieve the next page
+     * @return ListEventsResponse: The list of events retrieved, including total_size
+     */
+    @Override
+    public ListEventsResponse listEvents(EventFilter filter, int pageSize, String pageToken) {
+        String finalPageToken = pageToken;
+        int finalPageSize = pageSize;
+        if (Objects.isNull(finalPageToken)) {
+            finalPageToken = "";
+        }
+        if (finalPageSize <= 0) {
+            finalPageSize = 10;
+        }
+        final String effectivePageToken = finalPageToken;
+        final int effectivePageSize = finalPageSize;
+        return RetryExecuter.executeWithRetry(() -> {
+            ListEventsRequest request = ListEventsRequest.newBuilder()
+                    .setFilter(filter)
+                    .setPageSize(effectivePageSize)
+                    .setPageToken(effectivePageToken)
+                    .build();
+            return this.eventsStub
+                    .withDeadlineAfter(Environment.defaultConfig().timeout, TimeUnit.MILLISECONDS)
+                    .listEvents(request);
+        },this.credentials);
+    }
+
 }

--- a/src/test/java/AuditLogsTests.java
+++ b/src/test/java/AuditLogsTests.java
@@ -1,0 +1,98 @@
+import com.scalekit.ScalekitClient;
+import com.scalekit.grpc.scalekit.v1.auditlogs.*;
+import com.scalekit.grpc.scalekit.v1.events.EventFilter;
+import com.scalekit.grpc.scalekit.v1.events.ListEventsResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+public class AuditLogsTests {
+
+    private static ScalekitClient client;
+
+    @BeforeAll
+    static void init() {
+        String environmentUrl = System.getenv("SCALEKIT_ENVIRONMENT_URL");
+        String clientId = System.getenv("SCALEKIT_CLIENT_ID");
+        String apiSecret = System.getenv("SCALEKIT_CLIENT_SECRET");
+
+        client = new ScalekitClient(environmentUrl, clientId, apiSecret);
+    }
+
+    @Test
+    void ListAuthRequestsTest() {
+        ListAuthLogRequest request = ListAuthLogRequest.newBuilder()
+                .setPageSize(10)
+                .build();
+
+        ListAuthLogResponse response = client.auditLogs().listAuthRequests(request);
+
+        assertNotNull(response);
+        // The list may be empty for a fresh environment - that is a valid response.
+        assertNotNull(response.getAuthRequestsList());
+        assertDoesNotThrow(response::getTotalSize);
+    }
+
+    @Test
+    void ListAuthRequestsWithFiltersTest() {
+        ListAuthLogRequest request = ListAuthLogRequest.newBuilder()
+                .setEmail("nobody-matching@example.com")
+                .addAllStatus(Collections.singletonList("SUCCESS"))
+                .setPageSize(5)
+                .build();
+
+        ListAuthLogResponse response = client.auditLogs().listAuthRequests(request);
+
+        assertNotNull(response);
+        // A non-matching email filters out all logs, but the call still succeeds.
+        assertEquals(0, response.getAuthRequestsList().size());
+    }
+
+    /**
+     * Fetches real authentication request logs, takes a real authRequestId from the results,
+     * and confirms the Events API returns at least one event for that same authRequestId.
+     * No IDs are hardcoded — everything is fetched live from the environment. If the
+     * environment has no authentication request history, there is nothing to correlate, so
+     * the assertion is skipped rather than failed.
+     */
+    @Test
+    void EventsCorrelateWithAuthRequestIdTest() {
+        ListAuthLogRequest request = ListAuthLogRequest.newBuilder()
+                .setPageSize(50)
+                .build();
+
+        ListAuthLogResponse authResponse = client.auditLogs().listAuthRequests(request);
+        assertNotNull(authResponse);
+
+        String authRequestId = authResponse.getAuthRequestsList().stream()
+                .map(AuthLogRequest::getAuthRequestId)
+                .filter(id -> id != null && !id.isEmpty())
+                .findFirst()
+                .orElse(null);
+
+        Assumptions.assumeTrue(
+                authRequestId != null,
+                "No authentication request logs with an authRequestId were found in this "
+                        + "environment; nothing to correlate against the Events API."
+        );
+
+        EventFilter filter = EventFilter.newBuilder()
+                .setAuthRequestId(authRequestId)
+                .build();
+        ListEventsResponse eventsResponse = client.events().listEvents(filter, 10, "");
+
+        assertNotNull(eventsResponse);
+        assertTrue(
+                eventsResponse.getEventsList().size() > 0,
+                "Expected at least one event for authRequestId=" + authRequestId
+                        + ", which was returned by listAuthRequests, but the Events API returned none."
+        );
+    }
+
+}

--- a/src/test/java/EventsTests.java
+++ b/src/test/java/EventsTests.java
@@ -34,4 +34,39 @@ public class EventsTests {
         assertDoesNotThrow(response::getPrevPageToken);
     }
 
+    @Test
+    void ListEventsTest() {
+        ListEventsResponse response = client.events().listEvents(10, "");
+
+        assertNotNull(response);
+        assertNotNull(response.getEventsList());
+        assertDoesNotThrow(response::getTotalSize);
+    }
+
+    @Test
+    void ListEventsWithFiltersTest() {
+        EventFilter filter = EventFilter.newBuilder()
+                .setOrganizationId("org_does_not_exist")
+                .setSource(Source.SCALEKIT)
+                .build();
+
+        ListEventsResponse response = client.events().listEvents(filter, 5, "");
+
+        assertNotNull(response);
+        // A nonexistent organization_id filters out all events, but the call still succeeds.
+        assertEquals(0, response.getEventsList().size());
+    }
+
+    @Test
+    void ListEventsAuthRequestIdFilterNoMatchTest() {
+        EventFilter filter = EventFilter.newBuilder()
+                .setAuthRequestId("areq_does_not_exist")
+                .build();
+
+        ListEventsResponse response = client.events().listEvents(filter, 10, "");
+
+        assertNotNull(response);
+        assertEquals(0, response.getEventsList().size());
+    }
+
 }


### PR DESCRIPTION
## Description

Adds a new sub-client and a new method on an existing one:

- **`client.auditLogs().listAuthRequests(request)`** — new sub-client (`AuditLogsClient` / `ScalekitAuditLogsClient`) wrapping `AuditLogsService.ListAuthRequests` (`/api/v1/logs/authentication/requests`), newly promoted out of `PREVIEW` in the `scalekit` proto repo (companion PR). No wrapper existed for this service before — generated proto classes existed, but no `api`-level client, unlike every other service.
- **`client.events().listEvents(filter, pageSize, pageToken)`** — new method on the existing `EventsClient`, wrapping the plain, non-paginated `/api/v1/events` RPC. This SDK already wrapped `listEventsPaginated` (`/api/v1/events/paginated`), but not the un-paginated variant, which additionally returns a `total_size`.

`EventFilter.setAuthRequestId(...)` correlates directly with the `authRequestId` returned by `listAuthRequests`, so a caller can look up every event a specific login produced.

Follows this repo's established conventions: new method declared in both the interface and impl, explicit imports for all proto types, Javadoc on every public method, new sub-client registered in `ScalekitClient.java`. REFERENCE.md updated (new `listEvents` entries under the existing `## Events` section, new `## Audit Logs` section + TOC entry).

## Testing

- `mvn compile` and `mvn test-compile` — clean.
- New tests added: two new test methods in `EventsTests.java`, plus a new `AuditLogsTests.java`. **Not run in this session — no live `SCALEKIT_ENVIRONMENT_URL`/`CLIENT_ID`/`CLIENT_SECRET` were available.** They should run in CI, which holds real secrets.
- The cross-API correlation test (`EventsCorrelateWithAuthRequestIdTest`) fetches real `authRequestId` values from `listAuthRequests` at runtime — no IDs are hardcoded — then asserts `listEvents` returns at least one matching event. It uses `Assumptions.assumeTrue` to skip (rather than fail) if the environment has no authentication history to correlate against.
- Version bump intentionally **not** included yet — will follow once CI confirms tests pass (`pom.xml` + `Constants.java`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015D44Wzgoa1mHMRnAcw4qw6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving authentication audit logs.
  * Added event listing with pagination, filtering, and total result counts.
  * Added filtering events by authentication request ID to correlate activity with audit records.

* **Documentation**
  * Updated the API reference with audit log and event-listing examples and details.

* **Tests**
  * Added coverage for audit log retrieval, filtering, pagination, and audit-to-event correlation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->