### PR TITLE
ci: add Maven Central release workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hrishikesh-p @Avinash-Kamath
+* @hrishikesh-p @Avinash-Kamath @AkshayParihar33 @srinivaskarre-sk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # This job only runs `mvn deploy`; it never uses the GitHub token,
+          # so don't leave it persisted in the checkout for later steps.
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+# Publishes the SDK to Maven Central via the Sonatype Central Portal.
+# Triggered when a GitHub Release is published, or manually via the Actions tab.
+#
+# Because pom.xml sets autoPublish=false, `mvn deploy` uploads a *pending*
+# deployment bundle. Review and click Publish at:
+#   https://central.sonatype.com/publishing/deployments
+#
+# Required secrets (see deployment.md):
+#   NEXUS_USERNAME  - Sonatype Central Portal token username
+#   NEXUS_PASSWORD  - Sonatype Central Portal token password
+#   GPG_PRIVATE_KEY - ASCII-armored private key (gpg --armor --export-secret-keys <KEY_ID>)
+#   GPG_PASSPHRASE  - passphrase for the GPG key
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish to Maven Central
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          # setup-java writes ~/.m2/settings.xml with a <server id="central">
+          # block and imports the GPG key, so we don't hand-roll either.
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Deploy to Maven Central (pending in Portal)
+        run: mvn -B -ntp deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.NEXUS_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/deployment.md
+++ b/deployment.md
@@ -1,6 +1,11 @@
 # Deployment Guide
 
-This SDK is published to Maven Central via the [Sonatype Central Portal](https://central.sonatype.com), under the `com.scalekit` namespace. Publishing is **not automated in CI** — there is no `release.yml`/`publish.yml` workflow. It is a manual `mvn deploy` run from a maintainer's machine, using the `central-publishing-maven-plugin` and `maven-gpg-plugin` configured in `pom.xml`.
+This SDK is published to Maven Central via the [Sonatype Central Portal](https://central.sonatype.com), under the `com.scalekit` namespace, using the `central-publishing-maven-plugin` and `maven-gpg-plugin` configured in `pom.xml`.
+
+There are two ways to publish:
+
+- **Automated (recommended)** — the [`.github/workflows/release.yml`](.github/workflows/release.yml) GitHub Actions workflow runs on a published GitHub Release (or manual `workflow_dispatch`) and deploys from CI. See [Automated publishing via GitHub Actions](#automated-publishing-via-github-actions) below.
+- **Manual fallback** — run `mvn deploy` from a maintainer's machine, following steps 1–8 below.
 
 This guide assumes you are the **namespace owner** for `com.scalekit` (i.e. you have (or are creating) the account that owns/verified the namespace, not someone being added as an additional publisher by an existing owner).
 
@@ -51,29 +56,14 @@ Maven Central requires every published artifact to be signed. The `maven-gpg-plu
    ```bash
    gpg --keyserver keyserver.ubuntu.com --send-keys YOUR_KEY_ID
    ```
-3. Make sure `gpg-agent` is running so Maven can access the key without a passphrase prompt hanging the build, or configure the passphrase via `~/.m2/settings.xml`:
-   ```xml
-   <settings>
-     <servers>
-       <server>
-         <id>central</id>
-         <username>YOUR_TOKEN_USERNAME</username>
-         <password>YOUR_TOKEN_PASSWORD</password>
-       </server>
-     </servers>
-     <profiles>
-       <profile>
-         <id>gpg-sign</id>
-         <activation>
-           <activeByDefault>true</activeByDefault>
-         </activation>
-         <properties>
-           <gpg.passphrase>YOUR_GPG_PASSPHRASE</gpg.passphrase>
-         </properties>
-       </profile>
-     </profiles>
-   </settings>
-   ```
+3. Provide the passphrase to the build **without** storing it in plaintext. `maven-gpg-plugin` 3.x discourages `<gpg.passphrase>` in `settings.xml` (with `bestPractices` enabled it fails the build). Use one of:
+   - **Local, interactive:** prime `gpg-agent` before the build so the passphrase is cached — sign anything once (`echo test | gpg --clearsign`) and the agent supplies it non-interactively for `mvn deploy`.
+   - **Unattended / scripted:** export the passphrase via the environment variable the plugin reads by default:
+     ```bash
+     export MAVEN_GPG_PASSPHRASE='your-gpg-passphrase'
+     mvn clean deploy
+     ```
+   (This is the same mechanism CI uses — see the automated section below.)
 
 ## 6. Bump the version
 
@@ -96,6 +86,32 @@ This runs the full build (compile, test, javadoc jar, sources jar, shade, GPG si
 3. Click **Publish** to release it to Maven Central, or **Drop** to discard it.
 
 Once published, artifacts typically become searchable on [search.maven.org](https://search.maven.org) within ~30 minutes, and syncable to Maven Central proper within a few hours.
+
+## Automated publishing via GitHub Actions
+
+The [`.github/workflows/release.yml`](.github/workflows/release.yml) workflow runs `mvn deploy` from CI so you don't need any local setup. It triggers on a **published GitHub Release** or a manual **workflow_dispatch**, and runs in a protected `release` environment.
+
+`actions/setup-java` writes the `<server id="central">` block into `settings.xml` and imports the GPG key automatically — you only supply the values as secrets.
+
+### One-time setup
+
+1. In repo **Settings → Environments**, create an environment named **`release`** (optionally add required reviewers for an approval gate before each publish).
+2. In that environment, add these four secrets:
+
+   | Secret | Value |
+   |---|---|
+   | `NEXUS_USERNAME` | Central Portal token username (step 3 above) |
+   | `NEXUS_PASSWORD` | Central Portal token password |
+   | `GPG_PRIVATE_KEY` | ASCII-armored private key: `gpg --armor --export-secret-keys YOUR_KEY_ID` |
+   | `GPG_PASSPHRASE` | passphrase for that GPG key |
+
+   The private key must be the full armored block including the `-----BEGIN/END PGP PRIVATE KEY BLOCK-----` lines. Piping avoids clipboard mangling: `gpg --armor --export-secret-keys YOUR_KEY_ID | gh secret set GPG_PRIVATE_KEY --env release`.
+
+### Releasing
+
+1. Bump `<version>` in `pom.xml` and merge to `main`.
+2. Create a GitHub Release (tag = the new version). This triggers the workflow.
+3. As with a manual deploy, `autoPublish=false` means the bundle lands **pending** — confirm it at [central.sonatype.com/publishing/deployments](https://central.sonatype.com/publishing/deployments).
 
 ## Adding another publisher to the namespace
 

--- a/deployment.md
+++ b/deployment.md
@@ -1,0 +1,108 @@
+# Deployment Guide
+
+This SDK is published to Maven Central via the [Sonatype Central Portal](https://central.sonatype.com), under the `com.scalekit` namespace. Publishing is **not automated in CI** — there is no `release.yml`/`publish.yml` workflow. It is a manual `mvn deploy` run from a maintainer's machine, using the `central-publishing-maven-plugin` and `maven-gpg-plugin` configured in `pom.xml`.
+
+This guide assumes you are the **namespace owner** for `com.scalekit` (i.e. you have (or are creating) the account that owns/verified the namespace, not someone being added as an additional publisher by an existing owner).
+
+## 1. Create a Central Portal account
+
+1. Go to [central.sonatype.com](https://central.sonatype.com) and sign up using **username/password** (not Google/GitHub SSO — SSO-only accounts don't correctly surface OSSRH-migrated namespaces).
+2. Verify your email.
+
+## 2. Register/verify the namespace
+
+1. Go to **Publish → Namespace** ([central.sonatype.com/publishing/namespaces](https://central.sonatype.com/publishing/namespaces)).
+2. Add the namespace `com.scalekit`.
+3. Since `com.scalekit` is a domain-based namespace, verify ownership via the DNS TXT record challenge Sonatype provides (add the TXT record to the `scalekit.com` DNS zone).
+4. Once verified, the namespace shows as active under your account.
+
+## 3. Generate a Central Portal token
+
+1. In the Central Portal, go to your account → **Generate User Token**.
+2. This gives you a `username` / `password` pair (a token, not your login password) — copy both, they're only shown once.
+
+## 4. Add the token to your local Maven settings
+
+Add a `<server>` entry to `~/.m2/settings.xml` with the id `central` (this must match `publishingServerId` in `pom.xml`):
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>central</id>
+      <username>YOUR_TOKEN_USERNAME</username>
+      <password>YOUR_TOKEN_PASSWORD</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Never commit this file or these values to the repo.
+
+## 5. Set up GPG signing
+
+Maven Central requires every published artifact to be signed. The `maven-gpg-plugin` runs at the `verify` phase and needs a local GPG key.
+
+1. Generate a key if you don't have one:
+   ```bash
+   gpg --full-generate-key
+   ```
+2. Upload the **public** key to a keyserver so Sonatype can verify signatures:
+   ```bash
+   gpg --keyserver keyserver.ubuntu.com --send-keys YOUR_KEY_ID
+   ```
+3. Make sure `gpg-agent` is running so Maven can access the key without a passphrase prompt hanging the build, or configure the passphrase via `~/.m2/settings.xml`:
+   ```xml
+   <settings>
+     <servers>
+       <server>
+         <id>central</id>
+         <username>YOUR_TOKEN_USERNAME</username>
+         <password>YOUR_TOKEN_PASSWORD</password>
+       </server>
+     </servers>
+     <profiles>
+       <profile>
+         <id>gpg-sign</id>
+         <activation>
+           <activeByDefault>true</activeByDefault>
+         </activation>
+         <properties>
+           <gpg.passphrase>YOUR_GPG_PASSPHRASE</gpg.passphrase>
+         </properties>
+       </profile>
+     </profiles>
+   </settings>
+   ```
+
+## 6. Bump the version
+
+Update the `<version>` in `pom.xml` before releasing (Maven Central does not allow re-publishing an existing version).
+
+## 7. Deploy
+
+From the repo root:
+
+```bash
+mvn clean deploy
+```
+
+This runs the full build (compile, test, javadoc jar, sources jar, shade, GPG sign) and uploads a deployment bundle to Central via the `central-publishing-maven-plugin`.
+
+`autoPublish` is set to `false` in `pom.xml`, so the deployment lands in a **pending** state:
+
+1. Go to [central.sonatype.com/publishing/deployments](https://central.sonatype.com/publishing/deployments).
+2. Find the deployment, review it (Sonatype validates POM metadata, signatures, javadoc/sources presence).
+3. Click **Publish** to release it to Maven Central, or **Drop** to discard it.
+
+Once published, artifacts typically become searchable on [search.maven.org](https://search.maven.org) within ~30 minutes, and syncable to Maven Central proper within a few hours.
+
+## Adding another publisher to the namespace
+
+Namespace user management is not self-service. As the namespace owner:
+
+1. Have the person create their own Central Portal account (username/password, not SSO-only).
+2. Email **central-support@sonatype.com** requesting they be added as a publisher on `com.scalekit`, including their account email.
+3. Once added, they follow steps 3–5 above (their own token + their own GPG key) to deploy from their own machine — namespace access does not share credentials.
+
+You can view current publishers under **Publish → Namespace → (⋮ menu on the `com.scalekit` row) → View Users**.

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,13 @@
                         <goals>
                             <goal>sign</goal>
                         </goals>
+                        <configuration>
+                            <!-- Sign non-interactively in CI (no TTY for a passphrase prompt) -->
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Summary

Adds an automated path to publish the SDK to Maven Central via the Sonatype Central Portal, replacing the fully-manual local `mvn deploy`.

- **`.github/workflows/release.yml`** — publishes on GitHub Release `published` (plus manual `workflow_dispatch`), gated behind a protected `release` environment.
  - `actions/setup-java` writes the `~/.m2/settings.xml` `<server id="central">` block and imports the GPG key — no hand-rolled settings/GPG steps.
  - Runs `mvn -B -ntp deploy`. Since `pom.xml` keeps `autoPublish=false`, this uploads a **pending** bundle to review + Publish in the Portal.
- **`pom.xml`** — `maven-gpg-plugin` now uses `--pinentry-mode loopback` so signing works non-interactively in CI.
- **`deployment.md`** — documents both the manual and automated publishing paths, plus namespace/user management.

## Required before first run

Create these secrets **inside the `release` environment** (Settings → Environments → `release`):

| Secret | Value |
|---|---|
| `NEXUS_USERNAME` | Sonatype Central Portal token username |
| `NEXUS_PASSWORD` | Sonatype Central Portal token password |
| `GPG_PRIVATE_KEY` | ASCII-armored private key (`gpg --armor --export-secret-keys <KEY_ID>`) |
| `GPG_PASSPHRASE` | GPG key passphrase |

Optionally add required reviewers to the `release` environment for an approval gate.

## Notes

- No proto/buf steps in this job — deploy builds from committed sources only.
- Trigger and `autoPublish=false` chosen so a human still confirms the first releases; flip `autoPublish` to `true` later for hands-off publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Release workflow to publish the SDK to Maven Central via the Sonatype Central Portal.
  * Deployments are uploaded to a pending state for review before final publication.
* **Documentation**
  * Expanded the deployment guide with automated CI publishing and a manual maintainer fallback (including namespace verification and credentials setup).
  * Documented how to add additional publishers.
* **Improvements**
  * Improved CI-friendly GPG signing by enabling non-interactive signing for artifact verification/signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->