### PR TITLE
[SK-1568] fix: bump jackson-databind to 2.18.8 (patch GHSA-r7wm-3cxj-wff9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This is the official Java SDK for [Scalekit](https://scalekit.com) — the auth 
 **Gradle:**
 
 ```gradle
-implementation "com.scalekit:scalekit-sdk-java:2.3.0"
+implementation "com.scalekit:scalekit-sdk-java:2.3.1"
 ```
 
 **Maven:**
@@ -64,7 +64,7 @@ implementation "com.scalekit:scalekit-sdk-java:2.3.0"
 <dependency>
     <groupId>com.scalekit</groupId>
     <artifactId>scalekit-sdk-java</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.scalekit</groupId>
     <artifactId>scalekit-sdk-java</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
 
     <packaging>jar</packaging>
 
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.16.0</version>
+            <version>2.18.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -225,7 +225,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/src/main/java/com/scalekit/internal/Constants.java
+++ b/src/main/java/com/scalekit/internal/Constants.java
@@ -4,7 +4,7 @@ import io.grpc.Metadata;
 import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
 public class Constants {
 
-    public static String version = "2.3.0";
+    public static String version = "2.3.1";
     public static String SCALEKIT_REQUEST_TIMEOUT = "SCALEKIT_REQUEST_TIMEOUT";
     public static final String BEARER_TYPE = "Bearer";
 


### PR DESCRIPTION
## Summary

A customer's security team flagged **GHSA-r7wm-3cxj-wff9** against this SDK. The advisory affects `jackson-core`, which is pulled in transitively by our directly-declared `jackson-databind` 2.16.0 and shaded into the published jar (`com.scalekit.shaded.jackson`).

- **Vulnerability:** CWE-770 (allocation of resources without limits) in the async parser — memory-exhaustion / DoS. CVSS 8.7.
- **Affected:** `jackson-core < 2.18.8`. Our shaded jar contained `jackson-core` **2.16.0**.
- **Fix:** bump `jackson-databind` 2.16.0 → **2.18.8**, which transitively pulls the patched `jackson-core` **2.18.8**. (Note: 2.19.0–2.21.3 are also affected; 2.18.8 is the clean patched choice on the 2.18 line.)

## Changes

- `pom.xml`: `jackson-databind` 2.16.0 → 2.18.8
- `pom.xml`: `maven-shade-plugin` 3.4.0 → 3.6.0 — **required** for the Jackson bump to build. Jackson 2.18.x is a multi-release JAR containing Java 21 bytecode; shade 3.4.0's bundled ASM can't read it and fails with `Unsupported class file major version 65`. Shade is a build-time-only plugin — it does not affect consumers' runtime.
- `pom.xml` + `README.md`: SDK version 2.3.0 → 2.3.1

## Verification

- `mvn clean package` succeeds; the shaded jar now contains `jackson-core` **2.18.8** and `jackson-databind` **2.18.8** (verified via `PackageVersion.class`).
- **Java 8 compatibility preserved** — confirmed from the built jar:
  - SDK's own classes: bytecode major version **52** (Java 8) — compiler target `1.8` unchanged.
  - Base shaded `jackson-core` classes: major version **52** (Java 8).
  - Java 21 classes live only under `META-INF/versions/21/`, which Java 8 JVMs ignore entirely.
- Jackson API usage in this SDK is limited to stable core APIs (`ObjectMapper`, `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES`, `readValue`, `@JsonProperty`) — unchanged across 2.16 → 2.18, so no source changes were needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Gradle and Maven installation examples to use SDK version 2.3.1.

* **Chores**
  * Released SDK version 2.3.1.
  * Updated project build configuration to support the latest release and improve ongoing maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->